### PR TITLE
feat: add foreign key detection and PII masking configuration

### DIFF
--- a/cmd/delete_comments.go
+++ b/cmd/delete_comments.go
@@ -39,14 +39,13 @@ func runDeleteComments(cmd *cobra.Command, args []string) error {
 	defer dbAdapter.Close()
 	log.Println("INFO: Database connection established successfully.")
 
-	enricherCfg := enricher.Config{}
+	enricherCfg := enricher.Config{MaskPII: appCfg.MaskPII}
 	svc := enricher.NewService(dbAdapter, nil, enricherCfg)
 
 	tableFilters, err := utils.ParseTablesFlag(cfg.TablesRaw)
 	if err != nil {
 		return fmt.Errorf("error parsing --tables flag: %w", err)
 	}
-
 	deleteParams := enricher.GenerateDeleteSQLParams{
 		TableFilters: tableFilters,
 	}

--- a/cmd/get_comments.go
+++ b/cmd/get_comments.go
@@ -36,7 +36,7 @@ func runGetComments(cmd *cobra.Command, args []string) error {
 	defer dbAdapter.Close()
 	log.Println("INFO: Database connection established successfully.")
 
-	enricherCfg := enricher.Config{}
+	enricherCfg := enricher.Config{MaskPII: appCfg.MaskPII}
 	svc := enricher.NewService(dbAdapter, nil, enricherCfg)
 
 	getParams := enricher.GetCommentsParams{}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ var rootCmd = &cobra.Command{
 	Use:   "db_schema_enricher",
 	Short: "A tool to enrich database schema with metadata",
 	Long: `db_schema_enricher is a CLI tool that helps enrich database schemas
-with metadata like column descriptions, example values, and foreign key relationships.`,
+with metadata like column descriptions, example values, distinct values, null counts, and foreign key relationships.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		err := appCfg.LoadAndValidate()
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/GoogleCloudPlatform/db-context-enrichment
 
-go 1.22.7
+go 1.23.0
+
 toolchain go1.24.1
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.14.2
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/generative-ai-go v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbL
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -105,6 +107,7 @@ github.com/jackc/pgx/v5 v5.7.2 h1:mLoDLV6sonKlvjIEsV56SkWNCnuNv531l94GaIzO+XI=
 github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/microsoft/go-mssqldb v1.8.0 h1:7cyZ/AT7ycDsEoWPIXibd+aVKFtteUNhDGf3aobP+tw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,13 +92,15 @@ type AppConfig struct {
 	EnrichmentsRaw  string
 	ContextFilesRaw string
 	Model           string
+	MaskPII         bool
 }
 
 // NewAppConfig creates an AppConfig with default values.
 func NewAppConfig() *AppConfig {
 	return &AppConfig{
 		// Default values set here. They will be overridden by flags.
-		DryRun: true,
+		DryRun:  true,
+		MaskPII: true,
 		Database: DatabaseConfig{
 			SSLMode:            "disable",
 			UpdateExistingMode: "overwrite",

--- a/internal/database/foreign_key_test.go
+++ b/internal/database/foreign_key_test.go
@@ -1,0 +1,64 @@
+package database
+
+import (
+	"testing"
+)
+
+// TestForeignKeyReference verifies the ForeignKeyReference struct is properly defined
+func TestForeignKeyReference(t *testing.T) {
+	fk := ForeignKeyReference{
+		ReferencedTable:  "users",
+		ReferencedColumn: "id",
+		ConstraintName:   "fk_user_id",
+	}
+
+	if fk.ReferencedTable != "users" {
+		t.Errorf("Expected ReferencedTable to be 'users', got %s", fk.ReferencedTable)
+	}
+	if fk.ReferencedColumn != "id" {
+		t.Errorf("Expected ReferencedColumn to be 'id', got %s", fk.ReferencedColumn)
+	}
+	if fk.ConstraintName != "fk_user_id" {
+		t.Errorf("Expected ConstraintName to be 'fk_user_id', got %s", fk.ConstraintName)
+	}
+}
+
+// TestCommentDataWithForeignKeys verifies the CommentData struct includes ForeignKeys field
+func TestCommentDataWithForeignKeys(t *testing.T) {
+	foreignKeys := []ForeignKeyReference{
+		{
+			ReferencedTable:  "users",
+			ReferencedColumn: "id",
+			ConstraintName:   "fk_user_id",
+		},
+	}
+
+	commentData := CommentData{
+		TableName:      "orders",
+		ColumnName:     "user_id",
+		ColumnDataType: "int",
+		ExampleValues:  []string{"1", "2", "3"},
+		DistinctCount:  100,
+		NullCount:      0,
+		Description:    "Foreign key to users table",
+		ForeignKeys:    foreignKeys,
+	}
+
+	if len(commentData.ForeignKeys) != 1 {
+		t.Errorf("Expected 1 foreign key, got %d", len(commentData.ForeignKeys))
+	}
+
+	if commentData.ForeignKeys[0].ReferencedTable != "users" {
+		t.Errorf("Expected foreign key to reference 'users' table, got %s", commentData.ForeignKeys[0].ReferencedTable)
+	}
+}
+
+// TestDBAdapterInterface verifies that DB struct implements DBAdapter interface with new method
+func TestDBAdapterInterface(t *testing.T) {
+	// This test ensures that DB struct satisfies the DBAdapter interface
+	// If the interface is not properly implemented, this will fail at compile time
+	var _ DBAdapter = (*DB)(nil)
+
+	// Test passes if compilation succeeds
+	t.Log("DB struct successfully implements DBAdapter interface with GetForeignKeys method")
+}

--- a/internal/database/mysql/mysql_test.go
+++ b/internal/database/mysql/mysql_test.go
@@ -1,0 +1,126 @@
+package mysql
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/db-context-enrichment/internal/database"
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestMySQLGetForeignKeys(t *testing.T) {
+	tests := []struct {
+		name           string
+		tableName      string
+		columnName     string
+		expectedFKs    []database.ForeignKeyReference
+		expectedError  string
+		mockSetup      func(sqlmock.Sqlmock)
+	}{
+		{
+			name:       "Success with foreign keys found",
+			tableName:  "orders",
+			columnName: "customer_id",
+			expectedFKs: []database.ForeignKeyReference{
+				{
+					ReferencedTable:  "customers",
+					ReferencedColumn: "id",
+					ConstraintName:   "fk_orders_customer_id",
+				},
+			},
+			expectedError: "",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"referenced_table", "referenced_column", "constraint_name"}).
+					AddRow("customers", "id", "fk_orders_customer_id")
+				mock.ExpectQuery(`SELECT\s+REFERENCED_TABLE_NAME as referenced_table,\s+REFERENCED_COLUMN_NAME as referenced_column,\s+CONSTRAINT_NAME as constraint_name\s+FROM information_schema\.KEY_COLUMN_USAGE`).WithArgs("orders", "customer_id").WillReturnRows(rows)
+			},
+		},
+		{
+			name:          "No foreign keys found",
+			tableName:     "standalone_table",
+			columnName:    "id",
+			expectedFKs:   []database.ForeignKeyReference{},
+			expectedError: "",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"referenced_table", "referenced_column", "constraint_name"})
+				mock.ExpectQuery(`SELECT\s+REFERENCED_TABLE_NAME as referenced_table,\s+REFERENCED_COLUMN_NAME as referenced_column,\s+CONSTRAINT_NAME as constraint_name\s+FROM information_schema\.KEY_COLUMN_USAGE`).WithArgs("standalone_table", "id").WillReturnRows(rows)
+			},
+		},
+		{
+			name:          "Database query error",
+			tableName:     "test_table",
+			columnName:    "test_column",
+			expectedFKs:   nil,
+			expectedError: "error querying foreign keys for test_table.test_column",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT\s+REFERENCED_TABLE_NAME as referenced_table,\s+REFERENCED_COLUMN_NAME as referenced_column,\s+CONSTRAINT_NAME as constraint_name\s+FROM information_schema\.KEY_COLUMN_USAGE`).WithArgs("test_table", "test_column").WillReturnError(errors.New("database connection failed"))
+			},
+		},
+		{
+			name:          "Row scanning error",
+			tableName:     "test_table",
+			columnName:    "test_column",
+			expectedFKs:   nil,
+			expectedError: "error scanning foreign key data for test_table.test_column",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"referenced_table", "referenced_column", "constraint_name"}).
+					AddRow(nil, "id", "fk_test") // nil value will cause scan error
+				mock.ExpectQuery(`SELECT\s+REFERENCED_TABLE_NAME as referenced_table,\s+REFERENCED_COLUMN_NAME as referenced_column,\s+CONSTRAINT_NAME as constraint_name\s+FROM information_schema\.KEY_COLUMN_USAGE`).WithArgs("test_table", "test_column").WillReturnRows(rows)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock database
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("Failed to create mock database: %v", err)
+			}
+			defer mockDB.Close()
+
+			// Setup mock expectations
+			tt.mockSetup(mock)
+
+			// Create database wrapper
+			db := &database.DB{Pool: mockDB}
+
+			// Create handler and call GetForeignKeys
+			handler := mysqlHandler{}
+			result, err := handler.GetForeignKeys(db, tt.tableName, tt.columnName)
+
+			// Check error expectations
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', but got nil", tt.expectedError)
+				} else if err.Error() == "" || len(err.Error()) == 0 {
+					t.Errorf("Expected error containing '%s', but got empty error", tt.expectedError)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
+			}
+
+			// Check result expectations
+			if tt.expectedError == "" {
+				if len(result) != len(tt.expectedFKs) {
+					t.Errorf("Expected %d foreign keys, got %d", len(tt.expectedFKs), len(result))
+				} else {
+					for i, expectedFK := range tt.expectedFKs {
+						if result[i].ReferencedTable != expectedFK.ReferencedTable ||
+							result[i].ReferencedColumn != expectedFK.ReferencedColumn ||
+							result[i].ConstraintName != expectedFK.ConstraintName {
+							t.Errorf("Foreign key %d mismatch. Expected: %+v, Got: %+v", i, expectedFK, result[i])
+						}
+					}
+				}
+			}
+
+			// Ensure all expectations were met
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("Unfulfilled mock expectations: %v", err)
+			}
+		})
+	}
+}

--- a/internal/database/sqlserver/sqlserver_test.go
+++ b/internal/database/sqlserver/sqlserver_test.go
@@ -1,0 +1,127 @@
+package sqlserver
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/db-context-enrichment/internal/database"
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestSQLServerGetForeignKeys(t *testing.T) {
+	tests := []struct {
+		name           string
+		tableName      string
+		columnName     string
+		expectedFKs    []database.ForeignKeyReference
+		expectedError  string
+		mockSetup      func(sqlmock.Sqlmock)
+	}{
+		{
+			name:       "Success with foreign keys found",
+			tableName:  "orders",
+			columnName: "customer_id",
+			expectedFKs: []database.ForeignKeyReference{
+				{
+					ReferencedTable:  "customers",
+					ReferencedColumn: "id",
+					ConstraintName:   "FK_orders_customer_id",
+				},
+			},
+			expectedError: "",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"referenced_table", "referenced_column", "constraint_name"}).
+					AddRow("customers", "id", "FK_orders_customer_id")
+				mock.ExpectQuery(`SELECT\s+rt\.name as referenced_table,\s+rc\.name as referenced_column,\s+fk\.name as constraint_name\s+FROM sys\.foreign_keys fk`).WithArgs(sql.Named("p1", "orders"), sql.Named("p2", "customer_id")).WillReturnRows(rows)
+			},
+		},
+		{
+			name:          "No foreign keys found",
+			tableName:     "standalone_table",
+			columnName:    "id",
+			expectedFKs:   []database.ForeignKeyReference{},
+			expectedError: "",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"referenced_table", "referenced_column", "constraint_name"})
+				mock.ExpectQuery(`SELECT\s+rt\.name as referenced_table,\s+rc\.name as referenced_column,\s+fk\.name as constraint_name\s+FROM sys\.foreign_keys fk`).WithArgs(sql.Named("p1", "standalone_table"), sql.Named("p2", "id")).WillReturnRows(rows)
+			},
+		},
+		{
+			name:          "Database query error",
+			tableName:     "test_table",
+			columnName:    "test_column",
+			expectedFKs:   nil,
+			expectedError: "error querying foreign keys for test_table.test_column",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT\s+rt\.name as referenced_table,\s+rc\.name as referenced_column,\s+fk\.name as constraint_name\s+FROM sys\.foreign_keys fk`).WithArgs(sql.Named("p1", "test_table"), sql.Named("p2", "test_column")).WillReturnError(errors.New("database connection failed"))
+			},
+		},
+		{
+			name:          "Row scanning error",
+			tableName:     "test_table",
+			columnName:    "test_column",
+			expectedFKs:   nil,
+			expectedError: "error scanning foreign key data for test_table.test_column",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"referenced_table", "referenced_column", "constraint_name"}).
+					AddRow(nil, "id", "FK_test") // nil value will cause scan error
+				mock.ExpectQuery(`SELECT\s+rt\.name as referenced_table,\s+rc\.name as referenced_column,\s+fk\.name as constraint_name\s+FROM sys\.foreign_keys fk`).WithArgs(sql.Named("p1", "test_table"), sql.Named("p2", "test_column")).WillReturnRows(rows)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock database
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("Failed to create mock database: %v", err)
+			}
+			defer mockDB.Close()
+
+			// Setup mock expectations
+			tt.mockSetup(mock)
+
+			// Create database wrapper
+			db := &database.DB{Pool: mockDB}
+
+			// Create handler and call GetForeignKeys
+			handler := sqlServerHandler{}
+			result, err := handler.GetForeignKeys(db, tt.tableName, tt.columnName)
+
+			// Check error expectations
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', but got nil", tt.expectedError)
+				} else if err.Error() == "" || len(err.Error()) == 0 {
+					t.Errorf("Expected error containing '%s', but got empty error", tt.expectedError)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
+			}
+
+			// Check result expectations
+			if tt.expectedError == "" {
+				if len(result) != len(tt.expectedFKs) {
+					t.Errorf("Expected %d foreign keys, got %d", len(tt.expectedFKs), len(result))
+				} else {
+					for i, expectedFK := range tt.expectedFKs {
+						if result[i].ReferencedTable != expectedFK.ReferencedTable ||
+							result[i].ReferencedColumn != expectedFK.ReferencedColumn ||
+							result[i].ConstraintName != expectedFK.ConstraintName {
+							t.Errorf("Foreign key %d mismatch. Expected: %+v, Got: %+v", i, expectedFK, result[i])
+						}
+					}
+				}
+			}
+
+			// Ensure all expectations were met
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("Unfulfilled mock expectations: %v", err)
+			}
+		})
+	}
+}

--- a/internal/database/util.go
+++ b/internal/database/util.go
@@ -29,17 +29,25 @@ func GenerateMetadataCommentString(data *CommentData, enrichments map[string]boo
 	var commentParts []string
 	isReq := func(e string) bool { return isEnrichmentRequested(e, enrichments) }
 
-	if isReq("description") && data.Description != "" {
-		commentParts = append(commentParts, data.Description)
-	}
 	if isReq("examples") && formattedExamples != "" {
 		commentParts = append(commentParts, formattedExamples)
 	}
 	if isReq("distinct_values") && data.DistinctCount >= 0 {
-		commentParts = append(commentParts, fmt.Sprintf("Distinct: %d", data.DistinctCount))
+		commentParts = append(commentParts, fmt.Sprintf("Distinct Values: %d", data.DistinctCount))
 	}
 	if isReq("null_count") {
-		commentParts = append(commentParts, fmt.Sprintf("Nulls: %d", data.NullCount))
+		commentParts = append(commentParts, fmt.Sprintf("Null Count: %d |", data.NullCount))
+	}
+	if isReq("description") && data.Description != "" {
+		commentParts = append(commentParts, data.Description)
+	}
+	// Add foreign key information to comment
+	if isReq("foreign_keys") && len(data.ForeignKeys) > 0 {
+		var fkStrings []string
+		for _, fk := range data.ForeignKeys {
+			fkStrings = append(fkStrings, fmt.Sprintf(`\"%s\".\"%s\"`, fk.ReferencedTable, fk.ReferencedColumn))
+		}
+		commentParts = append(commentParts, fmt.Sprintf("Foreign Keys: [%s]", strings.Join(fkStrings, ", ")))
 	}
 
 	if len(commentParts) == 0 {

--- a/internal/enricher/enricher_foreign_key_test.go
+++ b/internal/enricher/enricher_foreign_key_test.go
@@ -1,0 +1,190 @@
+package enricher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/GoogleCloudPlatform/db-context-enrichment/internal/database"
+)
+
+// MockDBAdapter for testing foreign key collection
+type MockDBAdapter struct {
+	mock.Mock
+}
+
+func (m *MockDBAdapter) GetForeignKeys(tableName, columnName string) ([]database.ForeignKeyReference, error) {
+	args := m.Called(tableName, columnName)
+	return args.Get(0).([]database.ForeignKeyReference), args.Error(1)
+}
+
+func (m *MockDBAdapter) GetColumns(tableName string) ([]database.ColumnInfo, error) {
+	args := m.Called(tableName)
+	return args.Get(0).([]database.ColumnInfo), args.Error(1)
+}
+
+func (m *MockDBAdapter) GetTables() ([]string, error) {
+	args := m.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockDBAdapter) GetColumnMetadata(tableName, columnName string) (map[string]interface{}, error) {
+	args := m.Called(tableName, columnName)
+	return args.Get(0).(map[string]interface{}), args.Error(1)
+}
+
+func (m *MockDBAdapter) GenerateCommentSQL(data *database.CommentData, enrichments map[string]bool) (string, error) {
+	args := m.Called(data, enrichments)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockDBAdapter) GenerateDeleteCommentSQL(tableName, columnName string) (string, error) {
+	args := m.Called(tableName, columnName)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func TestCollectColumnDBMetadataWithForeignKeys(t *testing.T) {
+	tests := []struct {
+		name                string
+		enrichments         map[string]bool
+		expectedForeignKeys []database.ForeignKeyReference
+		foreignKeyError     error
+		expectForeignKeys   bool
+	}{
+		{
+			name: "foreign_keys_enrichment_requested_with_results",
+			enrichments: map[string]bool{
+				"foreign_keys": true,
+			},
+			expectedForeignKeys: []database.ForeignKeyReference{
+				{
+					ReferencedTable:  "users",
+					ReferencedColumn: "id",
+					ConstraintName:   "fk_orders_user_id",
+				},
+			},
+			foreignKeyError:   nil,
+			expectForeignKeys: true,
+		},
+		{
+			name: "foreign_keys_enrichment_not_requested",
+			enrichments: map[string]bool{
+				"examples": true,
+			},
+			expectedForeignKeys: nil,
+			foreignKeyError:     nil,
+			expectForeignKeys:   false,
+		},
+		{
+			name: "foreign_keys_enrichment_with_empty_results",
+			enrichments: map[string]bool{
+				"foreign_keys": true,
+			},
+			expectedForeignKeys: []database.ForeignKeyReference{},
+			foreignKeyError:     nil,
+			expectForeignKeys:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup mock
+			mockAdapter := &MockDBAdapter{}
+			service := &Service{
+				dbAdapter: mockAdapter,
+			}
+
+			// Setup expectations
+			if tt.expectForeignKeys {
+				mockAdapter.On("GetForeignKeys", "orders", "user_id").Return(tt.expectedForeignKeys, tt.foreignKeyError)
+			}
+
+			// Mock GetColumnMetadata for other enrichments
+			mockAdapter.On("GetColumnMetadata", "orders", "user_id").Return(map[string]interface{}{}, nil)
+
+			// Test data
+			colInfo := database.ColumnInfo{
+				Name:     "user_id",
+				DataType: "INTEGER",
+			}
+
+			// Execute
+			result, err := service.collectColumnDBMetadata(context.Background(), "orders", colInfo, tt.enrichments)
+
+			// Verify
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "orders", result.Table)
+			assert.Equal(t, "user_id", result.Column)
+			assert.Equal(t, "INTEGER", result.DataType)
+
+			if tt.expectForeignKeys {
+				assert.Equal(t, tt.expectedForeignKeys, result.ForeignKeys)
+			} else {
+				assert.Nil(t, result.ForeignKeys)
+			}
+
+			// Verify mock expectations
+			mockAdapter.AssertExpectations(t)
+		})
+	}
+}
+
+func TestForeignKeyIntegrationWithCommentData(t *testing.T) {
+	// Setup mock
+	mockAdapter := &MockDBAdapter{}
+	service := &Service{
+		dbAdapter: mockAdapter,
+	}
+
+	// Expected foreign keys
+	expectedForeignKeys := []database.ForeignKeyReference{
+		{
+			ReferencedTable:  "users",
+			ReferencedColumn: "id",
+			ConstraintName:   "fk_orders_user_id",
+		},
+	}
+
+	// Setup expectations
+	mockAdapter.On("GetForeignKeys", "orders", "user_id").Return(expectedForeignKeys, nil)
+	mockAdapter.On("GetColumnMetadata", "orders", "user_id").Return(map[string]interface{}{}, nil)
+
+	// Test data
+	colInfo := database.ColumnInfo{
+		Name:     "user_id",
+		DataType: "INTEGER",
+	}
+	enrichments := map[string]bool{
+		"foreign_keys": true,
+	}
+
+	// Execute
+	result, err := service.collectColumnDBMetadata(context.Background(), "orders", colInfo, enrichments)
+
+	// Verify
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, expectedForeignKeys, result.ForeignKeys)
+
+	// Verify that CommentData would be created correctly
+	commentData := &database.CommentData{
+		TableName:      result.Table,
+		ColumnName:     result.Column,
+		ColumnDataType: result.DataType,
+		ExampleValues:  result.ExampleValues,
+		DistinctCount:  result.DistinctCount,
+		NullCount:      result.NullCount,
+		Description:    result.Description,
+		ForeignKeys:    result.ForeignKeys,
+	}
+
+	assert.Equal(t, "orders", commentData.TableName)
+	assert.Equal(t, "user_id", commentData.ColumnName)
+	assert.Equal(t, expectedForeignKeys, commentData.ForeignKeys)
+
+	// Verify mock expectations
+	mockAdapter.AssertExpectations(t)
+}


### PR DESCRIPTION
- Add foreign key relationship detection across MySQL, PostgreSQL, and SQL Server
- Add mask_pii configuration flag to control LLM-based PII detection (default: true)
- Add retry logic with exponential backoff for Gemini API rate limiting
- Add some tests and some prompt tweaks
