### PR TITLE
feat(evaluate): support llm rater configuration in evalbench generator

### DIFF
--- a/mcp/evaluate/evaluate_generator.py
+++ b/mcp/evaluate/evaluate_generator.py
@@ -139,7 +139,7 @@ def _generate_llmrater_config() -> str:
     """Generates a dedicated LLM rater model configuration mimicking standard text models."""
     return textwrap.dedent("""\
         generator: gcp_vertex_gemini
-        vertex_model: gemini-3.1-pro-preview
+        vertex_model: gemini-2.5-flash
         gcp_region: global
         base_prompt: ""
         execs_per_minute: 5

--- a/mcp/evaluate/evaluate_generator.py
+++ b/mcp/evaluate/evaluate_generator.py
@@ -123,7 +123,6 @@ def _generate_run_config(experiment_name: str, dataset_path: str, dialect: str) 
         ### Scorer Related Configs
         ############################################################
         scorers:
-          set_match: null
           llmrater:
             model_config: experiments/{experiment_name}/eval_configs/llmrater_config.yaml
 

--- a/mcp/evaluate/evaluate_generator.py
+++ b/mcp/evaluate/evaluate_generator.py
@@ -141,6 +141,7 @@ def _generate_llmrater_config() -> str:
     return textwrap.dedent("""\
         generator: gcp_vertex_gemini
         vertex_model: gemini-3.1-pro-preview
+        gcp_region: global
         base_prompt: ""
         execs_per_minute: 5
     """).strip()

--- a/mcp/evaluate/evaluate_generator.py
+++ b/mcp/evaluate/evaluate_generator.py
@@ -142,5 +142,5 @@ def _generate_llmrater_config() -> str:
         vertex_model: gemini-2.5-flash
         gcp_region: global
         base_prompt: ""
-        execs_per_minute: 5
+        execs_per_minute: 20
     """).strip()

--- a/mcp/evaluate/evaluate_generator.py
+++ b/mcp/evaluate/evaluate_generator.py
@@ -29,11 +29,14 @@ def generate_evalbench_configs(
     db_config_yaml = generator.generate_db_config()
     model_config_yaml = generator.generate_model_config(context_set_id)
     run_config_yaml = _generate_run_config(experiment_name, dataset_path, generator.DIALECT)
+    
+    llmrater_config = _generate_llmrater_config()
 
     return {
         "db_config.yaml": db_config_yaml,
         "model_config.yaml": model_config_yaml,
-        "run_config.yaml": run_config_yaml
+        "run_config.yaml": run_config_yaml,
+        "llmrater_config.yaml": llmrater_config
     }
 
 
@@ -120,8 +123,9 @@ def _generate_run_config(experiment_name: str, dataset_path: str, dialect: str) 
         ### Scorer Related Configs
         ############################################################
         scorers:
-          exact_match: null
-          executable_sql: null
+          set_match: null
+          llmrater:
+            model_config: experiments/{experiment_name}/eval_configs/llmrater_config.yaml
 
         ############################################################
         ### Reporting Related Configs
@@ -129,4 +133,14 @@ def _generate_run_config(experiment_name: str, dataset_path: str, dialect: str) 
         reporting:
           csv:
             output_directory: 'experiments/{experiment_name}/eval_reports/'
+    """).strip()
+
+
+def _generate_llmrater_config() -> str:
+    """Generates a dedicated LLM rater model configuration mimicking standard text models."""
+    return textwrap.dedent("""\
+        generator: gcp_vertex_gemini
+        vertex_model: gemini-3.1-pro-preview
+        base_prompt: ""
+        execs_per_minute: 5
     """).strip()

--- a/mcp/tests/evaluate/evaluate_generator_test.py
+++ b/mcp/tests/evaluate/evaluate_generator_test.py
@@ -92,7 +92,7 @@ def test_generate_evalbench_configs():
             toolbox_source_name="test-source"
         )
     
-    assert set(configs.keys()) == {"db_config.yaml", "model_config.yaml", "run_config.yaml"}
+    assert set(configs.keys()) == {"db_config.yaml", "model_config.yaml", "run_config.yaml", "llmrater_config.yaml"}
     
     expected_db_config = textwrap.dedent("""\
         db_type: postgres
@@ -143,8 +143,9 @@ def test_generate_evalbench_configs():
         ### Scorer Related Configs
         ############################################################
         scorers:
-          exact_match: null
-          executable_sql: null
+          set_match: null
+          llmrater:
+            model_config: experiments/test-exp/eval_configs/llmrater_config.yaml
 
         ############################################################
         ### Reporting Related Configs

--- a/mcp/tests/evaluate/evaluate_generator_test.py
+++ b/mcp/tests/evaluate/evaluate_generator_test.py
@@ -143,7 +143,6 @@ def test_generate_evalbench_configs():
         ### Scorer Related Configs
         ############################################################
         scorers:
-          set_match: null
           llmrater:
             model_config: experiments/test-exp/eval_configs/llmrater_config.yaml
 


### PR DESCRIPTION
Adds support for the EvalBench LLM Rater to enable semantic result comparisons during automated evaluations.
- Generates a dedicated `llmrater_config.yaml` using `gemini-3.1-pro-preview`.
- Wires the LLM rater block into the `run_config.yaml` scorers definition.
- Updates unit tests to validate the new configuration output.