### PR TITLE
feat(evaluate): add custom runner configs to lower evalbench parallelism

### DIFF
--- a/mcp/evaluate/evaluate_generator.py
+++ b/mcp/evaluate/evaluate_generator.py
@@ -120,6 +120,13 @@ def _generate_run_config(experiment_name: str, dataset_path: str, dialect: str) 
         prompt_generator: 'NOOPGenerator'
 
         ############################################################
+        ### Evaluator Execution / Parallelism Tuning
+        ############################################################
+        runners:
+          eval_runners: 2
+          sqlgen_runners: 2
+
+        ############################################################
         ### Scorer Related Configs
         ############################################################
         scorers:

--- a/mcp/tests/evaluate/evaluate_generator_test.py
+++ b/mcp/tests/evaluate/evaluate_generator_test.py
@@ -140,6 +140,13 @@ def test_generate_evalbench_configs():
         prompt_generator: 'NOOPGenerator'
 
         ############################################################
+        ### Evaluator Execution / Parallelism Tuning
+        ############################################################
+        runners:
+          eval_runners: 2
+          sqlgen_runners: 2
+
+        ############################################################
         ### Scorer Related Configs
         ############################################################
         scorers:


### PR DESCRIPTION
## Changes
* Set `eval_runners: 2` and `sqlgen_runners: 2` in the generated `run_config.yaml`. 

## Why
To throttle concurrent requests and prevent Vertex AI quota exhaustion during multi-threaded execution.

This will increase the running time to around 4 minutes with our current settings with a high success rate.