### PR TITLE
docs(mcp): refine skills documentation for clarity and strictness

### DIFF
--- a/mcp/skills/autoctx-bootstrap/SKILL.md
+++ b/mcp/skills/autoctx-bootstrap/SKILL.md
@@ -20,7 +20,7 @@ Follow these steps exactly in order:
 1. **Condition Check & Schema Retrieval:**
    - You must explicitly ask the user for a descriptive name for this tuning experiment (e.g., `sales_db_tuning`). A new dedicated subfolder will be created inside the `experiments/` directory using this name to hold the entire tuning lifecycle and prevent any surprises. Do not proceed until you have their confirmation.
    - Use the available Toolbox MCP tools configured in the active `tools.yaml` to fetch the schemas for the target database.
-   - If the schema is large, ask the user if they want to filter or focus on specific tables before fetching everything. Skip to Final Summary if the user cancels.
+   - Present the retrieved schema summary **structurally and cleanly** to the user. If the schema is large, ask the user if they want to filter or focus on specific schemas or tables.
 
 2. **Deduce Key Info (Core Execution):**
    - **Analyze** the retrieved schema to identify important concepts, relationships, or likely query patterns.

--- a/mcp/skills/autoctx-evaluate/SKILL.md
+++ b/mcp/skills/autoctx-evaluate/SKILL.md
@@ -40,7 +40,7 @@ Follow these steps exactly in order:
 
 4. **Evalbench Run Integration:**
    - Trigger the `run_shell_command` natively to execute the evaluation from the ROOT of the workspace using the following exact command template:
-     `<skill_dir>/scripts/evalbench --experiment_config experiments/<experiment_name>/eval_configs/run_config.yaml`
+     `<skill_dir>/scripts/evalbench --experiment_config=experiments/<experiment_name>/eval_configs/run_config.yaml`
    - Check the command outputs to ensure the evaluation reports materialize in the respective `experiments/<experiment_name>/eval_reports/` directory.
 
 ## Output

--- a/mcp/skills/autoctx-hillclimb/SKILL.md
+++ b/mcp/skills/autoctx-hillclimb/SKILL.md
@@ -84,13 +84,13 @@ Follow these steps exactly in order:
     - **Proposed Mutation**: None. Flag to user to fix the evaluation dataset.
     ```
 
-5.  **Save Report**: Write the report to `experiments/<experiment_name>/hillclimb/gap_analysis_vN.md`.
+5.  **Save Report**: You **MUST** physically write the report file to `experiments/<experiment_name>/hillclimb/gap_analysis_vN.md`. Do not merely output it in chat; it must exist on the file system.
 6.  **Log in State Tracking**:
     -   Update `state.md` to record the mapping for Loop `vN` (Base Context <-> Eval Report <-> Gap Analysis).
 7.  **Human-in-the-Loop Review**:
-    -   Present the saved Gap Analysis report to the user.
-    -   Ask the user if they want to make any corrections or edits to the file before proceeding to Phase 2 (Context Mutation).
-    -   Wait for user confirmation or apply requested changes to the report before starting Phase 2.
+    -   Inform the user that the Gap Analysis report has been successfully written to disk.
+    -   Ask the user if they want to review, make any corrections, or add manual feedback directly to the file before proceeding to Phase 2 (Context Mutation).
+    -   Wait for user confirmation before starting Phase 2.
 
 ---
 

--- a/mcp/skills/autoctx-init/SKILL.md
+++ b/mcp/skills/autoctx-init/SKILL.md
@@ -30,7 +30,7 @@ Upon successful completion, the workspace must contain:
 
 Conclude by providing a succinct summary to the user:
 - State whether the workspace was initialized newly or if existing files were preserved.
-- Instruct the user to run `/mcp refresh` to apply any new database changes to the toolbox.
+- Instruct the user to run `/mcp reload` to apply any new database changes to the toolbox.
 - Inform them they are now ready to proceed to the next phase (e.g., the Bootstrap workflow).
 
 ---
@@ -56,7 +56,7 @@ When collecting information from the user, offer the option to use environment v
     - Cloud SQL MySQL
     - AlloyDB Postgres
     - Spanner
-2.  **Collect Information:** Request all **Required Information** based on the templates inside the `references/` folder.
+2.  **Collect Information:** Request all **Required Information** based on the templates inside the `references/` folder. Do NOT assume missing fields; ask the user for them explicitly.
 3.  **Generate Configuration:** Replace all placeholders with the user's provided values and generate the complete `tools.yaml` content. Save it to the current root directory.
 4.  **Validate:** After saving, validate the new connection using the toolbox script:
     `<skill_dir>/scripts/toolbox --tools-file tools.yaml invoke <data_source_name>-list-schemas`


### PR DESCRIPTION
## Summary
Refines the `SKILL.md` files for Autoctx workflows to improve agent reliability and command accuracy.
## Changes
- **Init**: Added guardrail against inventing missing fields; updated command to `/mcp reload`.
- **Bootstrap**: Instructed structured and clean presentation of database schemas.
- **Evaluate**: Fixed flag syntax to `--experiment_config=`.
- **Hill-Climb**: Strengthened instruction to physically write report files to disk.