### PR TITLE
feat(evaluate): use gemini-2.5-pro for evaluation rater

### DIFF
--- a/mcp/evaluate/evaluate_generator.py
+++ b/mcp/evaluate/evaluate_generator.py
@@ -146,7 +146,7 @@ def _generate_llmrater_config() -> str:
     """Generates a dedicated LLM rater model configuration mimicking standard text models."""
     return textwrap.dedent("""\
         generator: gcp_vertex_gemini
-        vertex_model: gemini-2.5-flash
+        vertex_model: gemini-2.5-pro
         gcp_region: global
         base_prompt: ""
         execs_per_minute: 20

--- a/mcp/skills/autoctx-bootstrap/SKILL.md
+++ b/mcp/skills/autoctx-bootstrap/SKILL.md
@@ -20,7 +20,7 @@ Follow these steps exactly in order:
 1. **Condition Check & Schema Retrieval:**
    - You must explicitly ask the user for a descriptive name for this tuning experiment (e.g., `sales_db_tuning`). A new dedicated subfolder will be created inside the `experiments/` directory using this name to hold the entire tuning lifecycle and prevent any surprises. Do not proceed until you have their confirmation.
    - Use the available Toolbox MCP tools configured in the active `tools.yaml` to fetch the schemas for the target database.
-   - If the schema is large, ask the user if they want to filter or focus on specific tables before fetching everything. Skip to Final Summary if the user cancels.
+   - Present the retrieved schema summary **structurally and cleanly** to the user. If the schema is large, ask the user if they want to filter or focus on specific schemas or tables.
 
 2. **Deduce Key Info (Core Execution):**
    - **Analyze** the retrieved schema to identify important concepts, relationships, or likely query patterns.

--- a/mcp/skills/autoctx-evaluate/SKILL.md
+++ b/mcp/skills/autoctx-evaluate/SKILL.md
@@ -40,7 +40,7 @@ Follow these steps exactly in order:
 
 4. **Evalbench Run Integration:**
    - Trigger the `run_shell_command` natively to execute the evaluation from the ROOT of the workspace using the following exact command template:
-     `<skill_dir>/scripts/evalbench --experiment_config experiments/<experiment_name>/eval_configs/run_config.yaml`
+     `<skill_dir>/scripts/evalbench --experiment_config=experiments/<experiment_name>/eval_configs/run_config.yaml`
    - Check the command outputs to ensure the evaluation reports materialize in the respective `experiments/<experiment_name>/eval_reports/` directory.
 
 ## Output

--- a/mcp/skills/autoctx-hillclimb/SKILL.md
+++ b/mcp/skills/autoctx-hillclimb/SKILL.md
@@ -84,13 +84,13 @@ Follow these steps exactly in order:
     - **Proposed Mutation**: None. Flag to user to fix the evaluation dataset.
     ```
 
-5.  **Save Report**: Write the report to `experiments/<experiment_name>/hillclimb/gap_analysis_vN.md`.
+5.  **Save Report**: You **MUST** physically write the report file to `experiments/<experiment_name>/hillclimb/gap_analysis_vN.md`. Do not merely output it in chat; it must exist on the file system.
 6.  **Log in State Tracking**:
     -   Update `state.md` to record the mapping for Loop `vN` (Base Context <-> Eval Report <-> Gap Analysis).
 7.  **Human-in-the-Loop Review**:
-    -   Present the saved Gap Analysis report to the user.
-    -   Ask the user if they want to make any corrections or edits to the file before proceeding to Phase 2 (Context Mutation).
-    -   Wait for user confirmation or apply requested changes to the report before starting Phase 2.
+    -   Inform the user that the Gap Analysis report has been successfully written to disk.
+    -   Ask the user if they want to review, make any corrections, or add manual feedback directly to the file before proceeding to Phase 2 (Context Mutation).
+    -   Wait for user confirmation before starting Phase 2.
 
 ---
 

--- a/mcp/skills/autoctx-init/SKILL.md
+++ b/mcp/skills/autoctx-init/SKILL.md
@@ -30,7 +30,7 @@ Upon successful completion, the workspace must contain:
 
 Conclude by providing a succinct summary to the user:
 - State whether the workspace was initialized newly or if existing files were preserved.
-- Instruct the user to run `/mcp refresh` to apply any new database changes to the toolbox.
+- Instruct the user to run `/mcp reload` to apply any new database changes to the toolbox.
 - Inform them they are now ready to proceed to the next phase (e.g., the Bootstrap workflow).
 
 ---
@@ -56,7 +56,7 @@ When collecting information from the user, offer the option to use environment v
     - Cloud SQL MySQL
     - AlloyDB Postgres
     - Spanner
-2.  **Collect Information:** Request all **Required Information** based on the templates inside the `references/` folder.
+2.  **Collect Information:** Request all **Required Information** based on the templates inside the `references/` folder. Do NOT assume missing fields; ask the user for them explicitly.
 3.  **Generate Configuration:** Replace all placeholders with the user's provided values and generate the complete `tools.yaml` content. Save it to the current root directory.
 4.  **Validate:** After saving, validate the new connection using the toolbox script:
     `<skill_dir>/scripts/toolbox --tools-file tools.yaml invoke <data_source_name>-list-schemas`

--- a/mcp/tests/evaluate/evaluate_generator_test.py
+++ b/mcp/tests/evaluate/evaluate_generator_test.py
@@ -120,6 +120,14 @@ def test_generate_evalbench_configs():
               agent_context_reference:
                 context_set_id: context-123
     """).strip()
+
+    expected_llmrater_config = textwrap.dedent("""\
+        generator: gcp_vertex_gemini
+        vertex_model: gemini-2.5-pro
+        gcp_region: global
+        base_prompt: ""
+        execs_per_minute: 20
+    """).strip()
     
     expected_run_config = textwrap.dedent("""\
         ############################################################
@@ -163,6 +171,7 @@ def test_generate_evalbench_configs():
     
     assert configs["db_config.yaml"] == expected_db_config
     assert configs["model_config.yaml"] == expected_model_config
+    assert configs["llmrater_config.yaml"] == expected_llmrater_config
     assert configs["run_config.yaml"] == expected_run_config
 
 


### PR DESCRIPTION
## Summary
Updates the evaluation configuration to use `gemini-2.5-pro` as the default model for the LLM rater to improve evaluation quality.
## Changes
- **Configuration Generator**: Updated `_generate_llmrater_config()` in `evaluate_generator.py` to use `gemini-2.5-pro`.
- **Tests**: Added an explicit assertion in `evaluate_generator_test.py` to verify the content of the generated `llmrater_config.yaml`.