### PR TITLE
chore: upgrade evalbench to 1.3.0

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -38,4 +38,4 @@ dev = [
 
 [tool.db-context-enrichment]
 toolbox_version = "0.31.0"
-evalbench_version = "1.1.0"
+evalbench_version = "1.3.0"


### PR DESCRIPTION
Upgraded `evalbench_version` from `1.1.0` to `1.3.0` in `mcp/pyproject.toml`.
