### PR TITLE
feat(facet): enforce qualified table names in prompts

### DIFF
--- a/mcp/prompts/targeted_facets.py
+++ b/mcp/prompts/targeted_facets.py
@@ -7,6 +7,7 @@ GENERATE_TARGETED_FACETS_PROMPT = textwrap.dedent(
     1.  **User Input Loop:**
         - Ask the user to provide an intent and its corresponding SQL snippet.
         - **Important:** Do not infer the intent or SQL snippet. Wait for the user to provide them.
+        - **Note:** Remind the user to use table-qualified column names (e.g., `table.column`) in the SQL snippet to avoid ambiguity.
         - After capturing the intent and SQL snippet pair, ask the user if they would like to add another one.
         - Continue this loop until the user indicates they have no more pairs to add.
 

--- a/mcp/skills/autoctx-bootstrap/SKILL.md
+++ b/mcp/skills/autoctx-bootstrap/SKILL.md
@@ -26,7 +26,8 @@ Follow these steps exactly in order:
 2. **Deduce Key Info (Core Execution):**
    - Perform a **deep analysis** of the retrieved **schema and any provided documentation or code** to identify important concepts, relationships, or likely query patterns.
    - **Templates**: Deduce key information for a set of query templates. For each, you need the natural language question (`question`), the corresponding `sql`, and the overall `intent`.
-   - **Facets**: Deduce key information for a set of SQL facets (reusable filters, conditions, expressions). For each, you need the `sql_snippet` and the `intent`.
+   - **Facets**: Deduce key information for a set of SQL facets (reusable filters, conditions, expressions). For each, you need the `sql_snippet` and the `intent`. 
+     - **Important**: Ensure `sql_snippet` uses table-qualified column names (e.g., `table.column`) to avoid ambiguity.
    - *Review Check:* Briefly display the deduced key info (templates and facets) to the user for approval or modifications before proceeding.
 
 3. **Context Generation (Core Execution):**


### PR DESCRIPTION
Enforces the use of fully qualified table names in SQL facets to prevent ambiguity during query injection. This updates both the bootstrap skill and targeted facet prompts to ensure the agent and user follow this practice.

