### PR TITLE
chore(ci): track pyproject.toml in release-please and align version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "db-context-enrichment"
-version = "0.3.0"
+version = "0.5.0"
 description = "A FastMCP server for generating natural language to SQL templates from database schemas."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,6 +31,11 @@
           "type": "json",
           "path": "gemini-extension.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.project.version"
         }
       ]
     }

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "db-context-enrichment"
-version = "0.3.0"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
This PR fixes a discrepancy where the Python project package version inside `pyproject.toml` was out of sync with the project's manifest (`.release-please-manifest.json`) and `gemini-extension.json`. It also configures Release Please to automate updates to `pyproject.toml` going forward.
## Proposed Changes
1. **Release Please Config:** Added `pyproject.toml` (type: `toml`, path: `pyproject.toml`, jsonpath: `$.project.version`) to the `extra-files` section of `release-please-config.json` so that Release Please automatically updates it during future releases.
2. **Version Alignment:** Aligned the stale package version in `pyproject.toml` from `0.3.0` to `0.5.0` to match the current release-please manifest.
3. **Lockfile Sync:** Synchronized package manager configuration using `uv lock`, upgrading `db-context-enrichment` to `0.5.0` inside `uv.lock`.