### PR TITLE
feat(config): bump default model to gemini-3.1-flash-lite

### DIFF
--- a/.ci/cloudbuild.yaml
+++ b/.ci/cloudbuild.yaml
@@ -60,10 +60,9 @@ steps:
         # Setup Python path and run evalbench
         export PYTHONPATH=/evalbench:/evalbench/evalproto
         export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
-        export PATH=/evalbench/.venv/bin:$PATH
 
         echo "Launching Standalone Evaluation..."
-        python3 /evalbench/evalbench/evalbench.py --experiment_config=core-cujs/run.yaml
+        uv run --project /evalbench python /evalbench/evalbench/evalbench.py --experiment_config=core-cujs/run.yaml
 
         # Mark that evaluation ran
         touch /workspace/EVAL_RAN

--- a/.ci/cloudbuild.yaml
+++ b/.ci/cloudbuild.yaml
@@ -60,6 +60,7 @@ steps:
         # Setup Python path and run evalbench
         export PYTHONPATH=/evalbench:/evalbench/evalproto
         export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+        export PATH=/evalbench/.venv/bin:$PATH
 
         echo "Launching Standalone Evaluation..."
         python3 /evalbench/evalbench/evalbench.py --experiment_config=core-cujs/run.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A FastMCP server for generating natural language to SQL templates
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "fastmcp>=2.12.5",
+    "fastmcp>=2.12.5,<2.14.3",
     "google-genai>=1.46.0",
     "toolbox-core>=0.5.2",
     "google-cloud-geminidataanalytics>=0.1.0",

--- a/src/google/cloud/db_context_enrichment/common/config.py
+++ b/src/google/cloud/db_context_enrichment/common/config.py
@@ -1,4 +1,4 @@
-MODEL_NAME = "gemini-2.5-flash"
+MODEL_NAME = "gemini-3.1-flash-lite"
 
 
 def get_model_name() -> str:

--- a/tests/google/cloud/db_context_enrichment/common/config_test.py
+++ b/tests/google/cloud/db_context_enrichment/common/config_test.py
@@ -2,4 +2,4 @@ from google.cloud.db_context_enrichment.common import config
 
 
 def test_get_model_name():
-    assert config.get_model_name() == "gemini-2.5-flash"
+    assert config.get_model_name() == "gemini-3.1-flash-lite"

--- a/tests/google/cloud/db_context_enrichment/evaluate/evaluate_generator_test.py
+++ b/tests/google/cloud/db_context_enrichment/evaluate/evaluate_generator_test.py
@@ -171,7 +171,7 @@ def test_generate_evalbench_configs():
 
     expected_llmrater_config = textwrap.dedent("""\
         generator: gcp_vertex_gemini
-        vertex_model: gemini-2.5-flash
+        vertex_model: gemini-3.1-flash-lite
         gcp_project_id: test-project
         gcp_region: global
         base_prompt: ""

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.12.5" },
+    { name = "fastmcp", specifier = ">=2.12.5,<2.14.3" },
     { name = "google-cloud-geminidataanalytics", specifier = ">=0.1.0" },
     { name = "google-genai", specifier = ">=1.46.0" },
     { name = "pytest", marker = "extra == 'test'" },


### PR DESCRIPTION
This PR bumps the default configured model from `gemini-2.5-flash` to `gemini-3.1-flash-lite`. 
Following its General Availability (GA) graduation, `gemini-2.5-flash` was restricted exclusively to the stable `v1` endpoint, and its preview routing alias was removed from the experimental `v1beta` endpoint. Because `genai.Client()` defaults to `v1beta` upon initialization, calls targeting `gemini-2.5-flash` began failing with `404 Not Found`. Bumping the default model to `gemini-3.1-flash-lite` ensures seamless compatibility with the default `v1beta` SDK endpoint and leverages the latest lightweight preview model capabilities.