### PR TITLE
Feat/dataset expansion

### DIFF
--- a/evals/core-cujs/dataset.json
+++ b/evals/core-cujs/dataset.json
@@ -19,12 +19,21 @@
       "max_turns": 5
     },
     {
+      "id": "autoctx-dataset-expansion",
+      "starting_prompt": "expand my evaluation dataset golden.json with more diverse examples using variation strategies.",
+      "conversation_plan": "Ask the agent to expand the existing golden.json evaluation dataset by applying variation strategies to the existing pairs. The agent should apply all six strategies: paraphrasing, merging, difficulty adjustment (both upscaling and simplification), distraction injection, linguistic variation (typos and synonyms), and value substitution (which requires running SELECT DISTINCT queries on the database). When the agent presents an expansion plan, confirm it and approve all strategies. When the agent runs SQL execution validation or asks for approval of the validation reports, approve them. You should terminate the conversation immediately after the agent successfully writes the expanded pairs to golden.json, even if the agent prompts you to perform evaluation or take next steps.",
+      "expected_trajectory": [],
+      "kind": "agents",
+      "work_dir": "workspace_post_dataset_generation/",
+      "max_turns": 8
+    },
+    {
       "id": "autoctx-bootstrap",
       "starting_prompt": "create initial context set for my alloydb database",
       "conversation_plan": "Ask the agent to create initial context set for my alloydb database. Need to have at least 2 templates and 2 facets. If prompted for experiment name, use 'my-alloydb-tuning-experiment'. You should terminate the conversation immediately after the agent successfully created the context set, even if the agent prompts you to perform evaluation or take next steps.",
       "expected_trajectory": [],
       "kind": "agents",
-      "work_dir": "workspace_post_dataset_generation/",
+      "work_dir": "workspace_post_expansion/",
       "max_turns": 5
     },
     {

--- a/evals/core-cujs/workspace_post_expansion/autoctx/state.md
+++ b/evals/core-cujs/workspace_post_expansion/autoctx/state.md
@@ -1,0 +1,1 @@
+# context authoring experiment state tracking

--- a/evals/core-cujs/workspace_post_expansion/autoctx/tools.yaml
+++ b/evals/core-cujs/workspace_post_expansion/autoctx/tools.yaml
@@ -1,0 +1,33 @@
+kind: source
+name: my-alloydb
+type: alloydb-postgres
+project: cloud-db-nl2sql
+region: us-central1
+cluster: whaoyu-test
+instance: whaoyu-test-primary
+database: financial
+---
+kind: tool
+name: my-alloydb-list-schemas
+type: postgres-list-tables
+source: my-alloydb
+description: |
+  Use this tool to list tables and their schemas in the my-alloydb database.
+
+  Progressive Schema Discovery (Recommended):
+  1) Fetch structure first (output_format='simple'),
+  2) Go deep on specific parts if interested,
+  3) Use batching if info is too large.
+
+  Scope:
+  - The tool can fetch system/extension schemas. Agents should ignore them and focus on user data.
+
+  Behavior:
+  - Omit 'table_names' to fetch all tables.
+  - Omit 'output_format' for detailed schema (default).
+---
+kind: tool
+name: my-alloydb-execute-sql
+type: postgres-execute-sql
+source: my-alloydb
+description: Use this tool to execute SQL statements against the my-alloydb database.

--- a/evals/core-cujs/workspace_post_expansion/golden.json
+++ b/evals/core-cujs/workspace_post_expansion/golden.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "eval_001",
+    "database": "financial",
+    "nlq": "How many accounts who choose issuance after transaction are staying in East Bohemia region? A3 contains the data of region; 'POPLATEK PO OBRATU' represents for 'issuance after transaction'.",
+    "golden_sql": "SELECT COUNT(DISTINCT \"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"district\" AS \"T2\" ON \"T1\".\"district_id\" = \"T2\".\"district_id\" WHERE \"T2\".\"A3\" = 'east Bohemia' AND \"T1\".\"frequency\" = 'POPLATEK PO OBRATU'"
+  },
+  {
+    "id": "eval_002",
+    "database": "financial",
+    "nlq": "How many accounts who have region in Prague are eligible for loans? A3 contains the data of region",
+    "golden_sql": "SELECT COUNT(\"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"loan\" AS \"T2\" ON \"T1\".\"account_id\" = \"T2\".\"account_id\" INNER JOIN \"district\" AS \"T3\" ON \"T1\".\"district_id\" = \"T3\".\"district_id\" WHERE \"T3\".\"A3\" = 'Prague'"
+  },
+  {
+    "id": "eval_003",
+    "database": "financial",
+    "nlq": "How many accounts who choose monthly issuance are staying in south Moravia region? 'POPLATEK MESICNE' represents for 'monthly issuance'.",
+    "golden_sql": "SELECT COUNT(DISTINCT \"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"district\" AS \"T2\" ON \"T1\".\"district_id\" = \"T2\".\"district_id\" WHERE \"T2\".\"A3\" = 'south Moravia' AND \"T1\".\"frequency\" = 'POPLATEK MESICNE'"
+  },
+  {
+    "id": "eval_004",
+    "database": "financial",
+    "nlq": "How many accounts who have region in south Bohemia are eligible for loans?",
+    "golden_sql": "SELECT COUNT(\"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"loan\" AS \"T2\" ON \"T1\".\"account_id\" = \"T2\".\"account_id\" INNER JOIN \"district\" AS \"T3\" ON \"T1\".\"district_id\" = \"T3\".\"district_id\" WHERE \"T3\".\"A3\" = 'south Bohemia'"
+  },
+  {
+    "id": "eval_005",
+    "database": "financial",
+    "nlq": "Count the accounts in the East Bohemia region that opted for issuance after transaction as their payment type. A3 contains the data of region; 'POPLATEK PO OBRATU' represents for 'issuance after transaction'.",
+    "golden_sql": "SELECT COUNT(DISTINCT \"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"district\" AS \"T2\" ON \"T1\".\"district_id\" = \"T2\".\"district_id\" WHERE \"T2\".\"A3\" = 'east Bohemia' AND \"T1\".\"frequency\" = 'POPLATEK PO OBRATU'",
+    "tags": ["complexity: medium", "topic: account_frequency", "source: expansion:paraphrase", "expansion_source_id: eval_001"]
+  },
+  {
+    "id": "eval_006",
+    "database": "financial",
+    "nlq": "Give me the total number of accounts in Prague that qualify for loans. A3 contains the data of region",
+    "golden_sql": "SELECT COUNT(\"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"loan\" AS \"T2\" ON \"T1\".\"account_id\" = \"T2\".\"account_id\" INNER JOIN \"district\" AS \"T3\" ON \"T1\".\"district_id\" = \"T3\".\"district_id\" WHERE \"T3\".\"A3\" = 'Prague'",
+    "tags": ["complexity: medium", "topic: loan_eligibility", "source: expansion:paraphrase", "expansion_source_id: eval_002"]
+  },
+  {
+    "id": "eval_007",
+    "database": "financial",
+    "nlq": "How many accounts with issuance after transaction as their payment type and located in Prague are also eligible for loans? A3 contains the data of region; 'POPLATEK PO OBRATU' represents for 'issuance after transaction'.",
+    "golden_sql": "SELECT COUNT(DISTINCT \"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"district\" AS \"T2\" ON \"T1\".\"district_id\" = \"T2\".\"district_id\" INNER JOIN \"loan\" AS \"T3\" ON \"T1\".\"account_id\" = \"T3\".\"account_id\" WHERE \"T2\".\"A3\" = 'Prague' AND \"T1\".\"frequency\" = 'POPLATEK PO OBRATU'",
+    "tags": ["complexity: high", "topic: loan_eligibility", "source: expansion:merge", "expansion_source_ids: [eval_001, eval_002]"]
+  },
+  {
+    "id": "eval_008",
+    "database": "financial",
+    "nlq": "How many accounts in each region are eligible for loans, listed from highest to lowest count? A3 contains the data of region",
+    "golden_sql": "SELECT \"T3\".\"A3\" AS region, COUNT(\"T1\".\"account_id\") AS eligible_accounts FROM \"account\" AS \"T1\" INNER JOIN \"loan\" AS \"T2\" ON \"T1\".\"account_id\" = \"T2\".\"account_id\" INNER JOIN \"district\" AS \"T3\" ON \"T1\".\"district_id\" = \"T3\".\"district_id\" GROUP BY \"T3\".\"A3\" ORDER BY eligible_accounts DESC",
+    "tags": ["complexity: high", "topic: regional_loan_distribution", "source: expansion:upscale", "expansion_source_id: eval_002"]
+  },
+  {
+    "id": "eval_009",
+    "database": "financial",
+    "nlq": "How many accounts are located in the East Bohemia region? A3 contains the data of region",
+    "golden_sql": "SELECT COUNT(DISTINCT \"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"district\" AS \"T2\" ON \"T1\".\"district_id\" = \"T2\".\"district_id\" WHERE \"T2\".\"A3\" = 'east Bohemia'",
+    "tags": ["complexity: low", "topic: regional_accounts", "source: expansion:simplify", "expansion_source_id: eval_001"]
+  },
+  {
+    "id": "eval_010",
+    "database": "financial",
+    "nlq": "How many accounts who have region in north Moravia are eligible for loans? A3 contains the data of region",
+    "golden_sql": "SELECT COUNT(\"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"loan\" AS \"T2\" ON \"T1\".\"account_id\" = \"T2\".\"account_id\" INNER JOIN \"district\" AS \"T3\" ON \"T1\".\"district_id\" = \"T3\".\"district_id\" WHERE \"T3\".\"A3\" = 'north Moravia'",
+    "tags": ["complexity: medium", "topic: loan_eligibility", "source: expansion:value_substitution", "expansion_source_id: eval_002", "substituted_column: district.A3"]
+  },
+  {
+    "id": "eval_011",
+    "database": "financial",
+    "nlq": "I was looking at the payment transactions table, but what I actually need is: how many accounts who choose monthly issuance are staying in south Moravia region? 'POPLATEK MESICNE' represents for 'monthly issuance'.",
+    "golden_sql": "SELECT COUNT(DISTINCT \"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"district\" AS \"T2\" ON \"T1\".\"district_id\" = \"T2\".\"district_id\" WHERE \"T2\".\"A3\" = 'south Moravia' AND \"T1\".\"frequency\" = 'POPLATEK MESICNE'",
+    "tags": ["complexity: medium", "topic: account_frequency", "source: expansion:distraction", "expansion_source_id: eval_003"]
+  },
+  {
+    "id": "eval_012",
+    "database": "financial",
+    "nlq": "Hw many acocunts who have their area in south Bohemia are eligible for credits?",
+    "golden_sql": "SELECT COUNT(\"T1\".\"account_id\") FROM \"account\" AS \"T1\" INNER JOIN \"loan\" AS \"T2\" ON \"T1\".\"account_id\" = \"T2\".\"account_id\" INNER JOIN \"district\" AS \"T3\" ON \"T1\".\"district_id\" = \"T3\".\"district_id\" WHERE \"T3\".\"A3\" = 'south Bohemia'",
+    "tags": ["complexity: medium", "topic: loan_eligibility", "source: expansion:linguistic", "expansion_source_id: eval_004"]
+  }
+]

--- a/evals/smoke-test/dataset.json
+++ b/evals/smoke-test/dataset.json
@@ -21,7 +21,7 @@
     {
       "id": "plugin:list-skills-and-mcp-tools",
       "starting_prompt": "Show the FULL list of Agent Skills and MCP tools you have available",
-      "conversation_plan": "Verify the db-context-engineering plugin loaded correctly. The agent should list its db-context-engineering skills (e.g., autoctx-init, autoctx-bootstrap, autoctx-dataset-generation, autoctx-evaluate, autoctx-hillclimb, context-generation-guide) and the MCP tools provided by the two plugin-configured servers: the `db-context-engineering` MCP server (e.g., generate_dataset, generate_evalbench_configs, generate_upload_url, mutate_context_set, read_evaluation_result) and the `toolbox` MCP server (*-list-schemas, *-execute-sql). Terminate the conversation immediately after the agent provides the list.",
+      "conversation_plan": "Verify the db-context-engineering plugin loaded correctly. The agent should list its db-context-engineering skills (e.g., autoctx-init, autoctx-bootstrap, autoctx-dataset-generation, autoctx-dataset-expansion, autoctx-evaluate, autoctx-hillclimb, context-generation-guide) and the MCP tools provided by the two plugin-configured servers: the `db-context-engineering` MCP server (e.g., generate_dataset, generate_evalbench_configs, generate_upload_url, mutate_context_set, read_evaluation_result) and the `toolbox` MCP server (*-list-schemas, *-execute-sql). Terminate the conversation immediately after the agent provides the list.",
       "expected_trajectory": [],
       "kind": "agents",
       "work_dir": "workspace_post_init/",

--- a/plugin/skills/autoctx-dataset-expansion/SKILL.md
+++ b/plugin/skills/autoctx-dataset-expansion/SKILL.md
@@ -1,0 +1,400 @@
+---
+name: autoctx-dataset-expansion
+description: "Expands an existing NLQ/SQL evaluation dataset using six structural variation strategies: paraphrasing, merging, difficulty adjustment, distraction injection, linguistic variation, and value substitution. Can be invoked standalone or from within other skills (e.g., the Expansion phase of autoctx-dataset-generation)."
+---
+
+# Auto Context Generation - Dataset Expansion Workflow
+
+This skill expands an existing NLQ/SQL evaluation dataset by applying targeted variation strategies to existing pairs. The goal is to increase dataset size, diversity, and robustness without requiring additional schema analysis or business context collection from scratch.
+
+> [!IMPORTANT]
+> **Prerequisite**: An existing source dataset (JSON file) in the [Standard Dataset Format](#standard-dataset-format) is required before this skill can operate. If no dataset exists yet, use the `autoctx-dataset-generation` skill first.
+
+## Input
+
+Before beginning the workflow, you explicitly require:
+
+- **Source dataset path**: Absolute path to the existing `golden.json` (or equivalent) in the Standard Dataset Format.
+- **Output file path**: Absolute path where expanded pairs should be written or appended. May be the same as the source file.
+- **Active `tools.yaml`** (located in `autoctx/`): Required for value substitution (Phase 3, Strategy 6) and for SQL execution validation (Phase 4). If `tools.yaml` is not present, value substitution will be skipped and SQL execution validation will be degraded to syntax-only checking — warn the user.
+- **Expansion strategies to apply** (ask the user): One or more of the six strategies listed below. Default to all six if the user has no preference.
+- **Target pair count or multiplier**: Either a fixed number of new pairs to generate (e.g., "add 20 pairs") or a multiplier on the source dataset (e.g., "2x the dataset"). Default to generating at minimum 1 expansion per source pair if unspecified.
+
+## Workflow
+
+Follow these steps exactly in order:
+
+---
+
+### Phase 1: Input Validation & Batch State Initialization
+
+1. **Read Source Dataset:**
+   - Read the source dataset file. Verify it is valid JSON matching the Standard Dataset Format. If malformed, STOP and report the error to the user.
+   - Count the total number of existing pairs and display a brief summary (pair count, distinct databases, complexity distribution from tags if present).
+
+2. **Batch ID Initialization (Crucial):**
+   - Scan the **output file** (if it already exists) for the highest existing `eval_<number>` ID.
+   - Auto-increment this integer to establish the `<pair_id>` for the current invocation (e.g., if highest is `eval_012`, the next starts at `eval_013`).
+   - If the output file does not exist or has no `eval_*` IDs, start at `eval_001`.
+   - If the source file and output file are different, also check the source file and take the maximum across both.
+   - Record the starting ID to ensure all pairs generated in this session use unique, sequential IDs.
+
+3. **Tools Check:**
+   - Check for `autoctx/tools.yaml`. If found, read it and identify the available database source(s).
+   - If `tools.yaml` is missing or has no supported source, warn the user:
+     > "No `tools.yaml` found. **Value Substitution** (Strategy 6) will be skipped and SQL execution validation will be limited to syntax checking only. To enable these features, run the `autoctx-init` skill first."
+   - If multiple sources are available, list them and ask the user which database to use for execution and schema queries.
+
+4. **Strategy & Target Confirmation:**
+   - If the user has not already specified which strategies to apply, present the full list (see [Expansion Strategies](#expansion-strategies)) and ask for confirmation.
+   - Confirm the total target number of new pairs.
+   - Do NOT proceed to Phase 2 until the user has confirmed.
+
+---
+
+### Phase 2: Expansion Planning
+
+Before generating any pairs, analyze the source dataset and produce a formal **Expansion Plan**.
+
+The plan must cover:
+
+1. **Source Dataset Analysis:**
+   - Complexity distribution: how many pairs are tagged `low`, `medium`, `high` (or estimate if tags are absent).
+   - Topic/domain coverage: which business themes appear.
+   - SQL feature coverage: what SQL constructs are already present (simple SELECTs, JOINs, aggregations, CTEs, subqueries, window functions, etc.).
+   - Pairs eligible for each strategy (e.g., only pairs with literal values in the NLQ are candidates for Value Substitution; only pairs that share related tables are candidates for Merging).
+
+2. **Strategy Allocation:**
+   - How many new pairs will each strategy contribute to reach the target count.
+   - Which source pairs are assigned to which strategies (can be approximate at this stage).
+   - Prioritize strategies that fill identified gaps (e.g., if the source dataset has no `high`-complexity pairs, prioritize Merging and Difficulty Upscaling).
+
+3. **Target Complexity Distribution:**
+   - Define the desired complexity distribution across all new pairs (e.g., 30% low, 40% medium, 30% high). Try to maintain or improve the distribution of the source dataset unless the user specifies otherwise.
+
+4. **Value Substitution Column Targets:**
+   - For pairs containing literal values, identify which column(s) to run `SELECT DISTINCT` on for candidate replacement values.
+
+5. **Validation Criteria:**
+   - All expanded SQL must be executable against the live database (if `tools.yaml` is available).
+   - All expanded pairs must pass the **Blind Test** (another agent could reconstruct the SQL from only the NLQ and business context).
+   - Pairs whose SQL returns 0 rows will be flagged but not automatically dropped — the user will decide.
+   - Pairs failing execution will be dropped automatically.
+
+> [!IMPORTANT]
+> **Always present the Expansion Plan to the user for confirmation or edits before proceeding to Phase 3.** Save the approved plan to `./evalset_states/plans/eval_dataset_expansion_plan.md` (create the directory if needed).
+
+---
+
+### Phase 3: Expansion Execution
+
+Apply each approved strategy using the source pairs identified in the plan. For every generated pair, execute the internal **Chain of Thought** described in each strategy below, then apply the [Cross-Strategy Validation Rules](#cross-strategy-validation-rules).
+
+Use the following internal tracking format per generated candidate (not written to the output file — internal reasoning only):
+- `source_id`: the `id` of the source pair(s)
+- `strategy`: which strategy produced this candidate
+- `status`: `pending_validation` | `approved` | `dropped`
+
+---
+
+#### Strategy 1: Paraphrasing
+
+**Goal:** Reword the NLQ into a semantically equivalent question while keeping the SQL 100% unchanged.
+
+**When to apply:** Any pair in the source dataset. Highly recommended for pairs with `complexity: low` or `complexity: medium` as they have simpler, more universally rephrashable NLQs.
+
+**Execution steps:**
+1. Read the source NLQ.
+2. Generate 1–3 paraphrase variants that:
+   - Change sentence structure (e.g., question → imperative, formal → informal, verbose → concise).
+   - Replace business terms with synonyms where unambiguous (e.g., "accounts" → "customers", "retrieve" → "find").
+   - Vary perspective (e.g., "How many X?" → "Give me the count of X" → "What is the total number of X?").
+3. Do NOT change the `golden_sql`.
+4. Apply the Blind Test: given only the new NLQ and the business domain, would the correct SQL be unambiguous? If a paraphrase loses precision (e.g., loses a key filter condition), discard it.
+5. Tag: `"source: expansion:paraphrase"`.
+
+**Example:**
+- Source NLQ: `"How many accounts who choose issuance after transaction are staying in East Bohemia region?"`
+- Paraphrase: `"Count the accounts in the East Bohemia region that opted for issuance after transaction."`
+- SQL: *(unchanged)*
+
+---
+
+#### Strategy 2: Merging
+
+**Goal:** Combine two or more source pairs into a single, more sophisticated NLQ/SQL pair using subqueries, CTEs, or multi-condition logic.
+
+**When to apply:** Source pairs that share at least one common table or concept. Do NOT merge pairs from different databases.
+
+**Execution steps:**
+1. Identify 2–3 source pairs that are logically composable (e.g., one filters accounts by region, another filters by loan eligibility).
+2. Draft the merged SQL first (schema-first approach):
+   - Use a CTE, subquery, or compound WHERE clause to represent the combined logic.
+   - Verify all table references and join conditions are valid against the schema.
+   - Run the merged SQL via `<source>-execute-sql` to confirm it is executable.
+3. Translate the merged SQL to a literal English description, then humanize it following the Semantic Bridge principle.
+4. Apply the Blind Test.
+5. Set `complexity` tag to at least one level higher than the highest-complexity source pair.
+6. Tag: `"source: expansion:merge"`, `"expansion_source_ids: [eval_001, eval_002]"`.
+
+**Example:**
+- Source 1: "How many accounts are in Prague?" → `SELECT count(*) FROM account JOIN district ON ... WHERE A3 = 'Prague'`
+- Source 2: "Which accounts have loans?" → `SELECT account_id FROM loan`
+- Merged NLQ: `"How many accounts located in Prague are also eligible for loans?"`
+- Merged SQL: `SELECT COUNT(DISTINCT a.account_id) FROM account a JOIN district d ON a.district_id = d.district_id JOIN loan l ON a.account_id = l.account_id WHERE d.A3 = 'Prague'`
+
+---
+
+#### Strategy 3: Difficulty Adjustment
+
+**Goal:** Create a simpler or more sophisticated variant of a single source pair by adding or removing SQL constructs.
+
+**When to apply:**
+- **Downscaling**: Source pairs with `complexity: medium` or `complexity: high`.
+- **Upscaling**: Source pairs with `complexity: low` or `complexity: medium`.
+
+**Execution steps — Downscaling (Simplification):**
+1. Identify a complex construct to remove: a JOIN, aggregation, subquery, window function, or a specific WHERE clause condition.
+2. Rewrite the SQL with the construct removed, ensuring the result is still a valid, meaningful query.
+3. Adjust the NLQ to accurately reflect the simplified question (dropping the nuance that was removed).
+4. Reduce the `complexity` tag accordingly.
+5. Tag: `"source: expansion:simplify"`.
+
+**Execution steps — Upscaling (Sophistication):**
+1. Identify an opportunity to add a meaningful construct: add a `GROUP BY` + aggregation, convert a flat query to a CTE, add a `HAVING` clause, add a ranking window function (`ROW_NUMBER`, `RANK`), add an additional JOIN to another related table, or add a date/range filter.
+2. Draft the enriched SQL (schema-first). Confirm all new column/table references exist in the schema.
+3. Run via `<source>-execute-sql` to confirm executability.
+4. Update the NLQ to accurately reflect the added complexity.
+5. Increase the `complexity` tag accordingly.
+6. Tag: `"source: expansion:upscale"`.
+
+---
+
+#### Strategy 4: Distraction Injection
+
+**Goal:** Add misleading or irrelevant information to the NLQ that does NOT change the SQL. This tests whether the Data Agent can filter noise from user questions.
+
+**When to apply:** Any pair, but prefer pairs with `complexity: low` or `complexity: medium` where the added noise is clearly extraneous.
+
+**Distraction types:**
+- **Irrelevant entity mention**: Mention a table or concept that is not part of the SQL (e.g., "I looked at the transactions table but I actually want to know...").
+- **Redundant condition**: Add a condition that is always true or subsumed by an existing condition (e.g., "...where the account exists AND is in Prague" when the Prague filter already implies existence).
+- **Out-of-scope qualifier**: Add a time-based or status-based qualifier that sounds meaningful but maps to no column (e.g., "as of today", "currently active" when there is no status column). Only use this if the schema genuinely lacks such a column — do not invent filters.
+- **Conversational filler**: Add preamble like "I was wondering...", "Can you help me find...", or "For a report I'm building...".
+
+**Execution steps:**
+1. Choose one distraction type appropriate to the pair.
+2. Inject the distraction into the NLQ only. The `golden_sql` must remain bit-for-bit identical.
+3. Apply the Blind Test with extra scrutiny: confirm that the distraction does NOT cause ambiguity about which SQL should be produced.
+4. Tag: `"source: expansion:distraction"`.
+
+---
+
+#### Strategy 5: Linguistic Variation
+
+**Goal:** Introduce realistic linguistic noise — typos, synonyms, domain acronyms — that a real user might type. This tests robustness to imperfect natural language input.
+
+**When to apply:** Any pair. Apply sparingly — 1–2 variants per source pair maximum. Do NOT apply linguistic variation to already-distraction-injected variants of the same pair.
+
+**Variation types (apply one or two per variant, not all at once):**
+
+- **Typos**: Introduce 1–2 plausible typing errors in the NLQ (e.g., "acocunts" for "accounts", "hwo many" for "how many"). Do NOT introduce typos in values that map directly to SQL literals (e.g., don't typo `'POPLATEK PO OBRATU'` if it appears in the NLQ, as that would make the Blind Test ambiguous).
+- **Synonyms**: Replace business terms with synonyms (e.g., "clients" → "customers", "loan" → "credit", "region" → "area", "eligible" → "qualified").
+- **Acronyms**: Replace spelled-out terms with domain acronyms where plausible (e.g., "natural language query" → "NLQ", "year to date" → "YTD", "month over month" → "MoM").
+- **Informal phrasing**: Use colloquial contractions or casual phrasing (e.g., "what's" instead of "what is", "gimme" instead of "give me", "show me" instead of "retrieve").
+
+**Execution steps:**
+1. Select 1–2 variation types from the list above.
+2. Apply them to the NLQ. The `golden_sql` must remain unchanged.
+3. Apply the Blind Test: despite the noise, would a skilled agent still produce the correct SQL? If the variation makes the question too ambiguous, discard it.
+4. Tag: `"source: expansion:linguistic"`.
+
+---
+
+#### Strategy 6: Value Substitution
+
+**Goal:** Replace a literal value mentioned in the NLQ (and its corresponding SQL literal) with a different real value from the same column. This generates semantically identical pairs with different parameters, improving value-coverage in the dataset.
+
+**When to apply:** Pairs that contain at least one literal string or numeric value in both the NLQ and the SQL WHERE clause (e.g., `WHERE district.A3 = 'Prague'` with "Prague" also appearing in the NLQ).
+
+> [!IMPORTANT]
+> This strategy **requires** an active `tools.yaml` and a live database connection. If unavailable, skip this strategy entirely and notify the user.
+
+**Execution steps:**
+1. Identify the literal value(s) in the NLQ that map directly to a SQL WHERE clause literal.
+2. For each identified value, determine its source table and column (e.g., `district.A3 = 'Prague'` → table `district`, column `A3`).
+3. **Run value discovery query:**
+   ```sql
+   SELECT DISTINCT "<column>" FROM "<table>" WHERE "<column>" IS NOT NULL ORDER BY 1 LIMIT 20;
+   ```
+   Execute this via `<source>-execute-sql`.
+4. Remove the source value from the candidate list. Select 1–3 alternative values.
+5. For each alternative value:
+   a. Replace the literal in the `golden_sql` WHERE clause.
+   b. Replace the corresponding term in the NLQ (use the exact value or a natural equivalent).
+   c. Run the substituted SQL via `<source>-execute-sql` to confirm it executes and returns rows.
+   d. If it returns 0 rows, flag with `"result: empty_result"` tag and ask the user whether to include or drop it.
+   e. Apply the Blind Test.
+6. Tag: `"source: expansion:value_substitution"`, `"substituted_column: <table>.<column>"`.
+
+**Example:**
+- Source NLQ: `"How many accounts in Prague are eligible for loans?"`
+- Source SQL: `...WHERE district.A3 = 'Prague'`
+- Value discovery: `SELECT DISTINCT "A3" FROM "district" ORDER BY 1 LIMIT 20` → returns `['Prague', 'south Bohemia', 'east Bohemia', 'north Moravia', ...]`
+- Substituted pair: `"How many accounts in south Bohemia are eligible for loans?"` with SQL: `...WHERE district.A3 = 'south Bohemia'`
+
+---
+
+### Cross-Strategy Validation Rules
+
+Apply these rules to every candidate pair, regardless of strategy, before marking it `approved`:
+
+1. **SQL Execution (if `tools.yaml` available):**
+   - Execute the `golden_sql` via `<source>-execute-sql`.
+   - If execution throws an error → mark `dropped`. Log the error in the validation report.
+   - If execution returns 0 rows → mark `flagged:empty_result`. Do NOT auto-drop. Report to user and wait for instruction.
+   - If execution returns rows → mark `approved` (subject to Blind Test below).
+
+2. **Blind Test:**
+   - Look only at the new NLQ (and the database name/domain). Could another agent unambiguously produce the exact `golden_sql`?
+   - If the NLQ is too vague, ambiguous, or inconsistent with the SQL → refine the NLQ or mark `dropped`.
+
+3. **Schema Fidelity:**
+   - No invented table names or column names in `golden_sql`.
+   - All column references exist in the schema (cross-check if schema was fetched in Phase 1).
+
+4. **No Duplication:**
+   - Check the output file for near-identical NLQs. Do not add pairs that are trivially identical to an already-existing pair.
+
+5. **Semantic Bridge:**
+   - The NLQ must use business vocabulary, not raw SQL column/table names (e.g., NLQ should say "region" not `A3`, "issuance frequency" not `frequency`). Exception: if the column name is itself a natural business term.
+
+---
+
+### Phase 4: Validation Report
+
+After all candidates have been processed through Cross-Strategy Validation, generate a two-tier validation report.
+
+> [!IMPORTANT]
+> **Present the validation report plan to the user for confirmation before writing the reports.** Save the approved review plan to `./evalset_states/plans/eval_dataset_expansion_review_plan.md`.
+
+**Tier 1 — Pair-Level Review:**
+
+For every candidate pair (approved, dropped, and flagged), produce a structured entry:
+
+```markdown
+### Pair: <new_id> (from <source_id> via <strategy>)
+- **Status**: Approved | Dropped | Flagged:empty_result
+- **NLQ**: "<the NLQ>"
+- **SQL**: `<the golden_sql>`
+- **Execution Result**: Returned N rows | Error: <message> | 0 rows (flagged)
+- **Blind Test**: Pass | Fail — <reason if fail>
+- **Drop/Flag Reason**: <if applicable>
+- **Complexity**: low | medium | high
+- **Topic**: <business domain>
+```
+
+Save to `./evalset_states/reports/eval-dataset-expansion-review-pair-level.md`.
+
+**Tier 2 — Dataset-Level Summary:**
+
+Aggregate across all approved pairs:
+
+```markdown
+# Dataset Expansion Summary
+
+## Source Dataset
+- Total source pairs: N
+- Databases: [list]
+
+## Expansion Results
+| Strategy             | Candidates | Approved | Dropped | Flagged (0 rows) |
+|----------------------|------------|----------|---------|-----------------|
+| Paraphrase           | X          | X        | X       | X               |
+| Merge                | X          | X        | X       | X               |
+| Difficulty Adjust    | X          | X        | X       | X               |
+| Distraction          | X          | X        | X       | X               |
+| Linguistic Variation | X          | X        | X       | X               |
+| Value Substitution   | X          | X        | X       | X               |
+| **Total**            | **X**      | **X**    | **X**   | **X**           |
+
+## Complexity Distribution (Approved Pairs)
+- Low: X (X%)
+- Medium: X (X%)
+- High: X (X%)
+
+## SQL Feature Coverage (Approved Pairs)
+- Simple SELECT: X
+- Aggregation (COUNT, SUM, AVG): X
+- JOINs: X
+- GROUP BY / HAVING: X
+- Subqueries / CTEs: X
+- Window Functions: X
+
+## Topics Covered
+<list of distinct topic tags>
+```
+
+Save to `./evalset_states/reports/eval-dataset-expansion-review-dataset-level.md`.
+
+Present both reports to the user. Wait for their confirmation (and any manual overrides for flagged pairs) before writing to the output file.
+
+---
+
+### Phase 5: Output
+
+1. **Apply User Overrides:** If the user manually approved any `flagged:empty_result` pairs or restored any dropped pairs, update their status to `approved`.
+
+2. **Write Approved Pairs:** Use the `generate_dataset` MCP tool to append all `approved` pairs to the output file path. Always use the **absolute path**. Pairs must conform to the Standard Dataset Format.
+
+3. **Assign Tags:** Every expanded pair must include:
+   - `"complexity: <low|medium|high>"`
+   - `"topic: <business_domain>"`
+   - `"source: expansion:<strategy_name>"` (e.g., `"source: expansion:paraphrase"`)
+   - `"expansion_source_id: <source_pair_id>"` (for single-source strategies)
+   - `"expansion_source_ids: [<id1>, <id2>]"` (for Merge strategy only)
+   - Where applicable: `"substituted_column: <table>.<column>"` (Value Substitution only)
+
+4. **Final Summary:** Report to the user:
+   - Total approved pairs written.
+   - Breakdown by strategy.
+   - Final combined dataset size (original + new).
+   - Exact output file path.
+   - Suggest next step: run evaluation using the `autoctx-evaluate` skill on the expanded dataset.
+
+---
+
+## Standard Dataset Format
+
+All input and output files must use this JSON schema:
+
+```json
+[
+    {
+        "id": "eval_001",
+        "database": "<database_name>",
+        "nlq": "How many accounts in Prague are eligible for loans?",
+        "golden_sql": "SELECT COUNT(DISTINCT a.account_id) FROM account a JOIN district d ON a.district_id = d.district_id JOIN loan l ON a.account_id = l.account_id WHERE d.A3 = 'Prague'",
+        "tags": [
+            "complexity: medium",
+            "topic: loan_eligibility",
+            "source: expansion:value_substitution",
+            "expansion_source_id: eval_002",
+            "substituted_column: district.A3"
+        ]
+    }
+]
+```
+
+- **`complexity`**: `"low"` (single table, no aggregation), `"medium"` (multi-table JOIN or aggregation), `"high"` (CTEs, subqueries, window functions, multi-condition logic).
+- **`topic`**: Business domain or analytical theme (e.g., `"loan_eligibility"`, `"account_activity"`, `"regional_distribution"`).
+- **`source`**: Must include the prefix `"expansion:"` followed by the strategy name for all pairs generated by this skill.
+- **`expansion_source_id`** / **`expansion_source_ids`**: Traceability back to the original pair(s).
+
+## Interaction Guidelines
+
+- **Confirm at every gate:** This skill has two mandatory user confirmation gates — after presenting the Expansion Plan (Phase 2) and after presenting the Validation Reports (Phase 4). Do not skip these.
+- **Be transparent about drops:** Always report exactly why a candidate was dropped — SQL execution error, Blind Test failure, or schema violation.
+- **Batch efficiently:** When running SQL execution for validation, batch `<source>-execute-sql` calls efficiently rather than one at a time where the tooling supports it.
+- **Respect the source dataset's domain:** Do not generate NLQs that venture into business domains not reflected in the source dataset unless the user explicitly requests broadening the scope.
+- **Do not over-expand:** Avoid creating so many near-identical variants of a single pair that the dataset becomes repetitive. Aim for diversity first.

--- a/plugin/skills/autoctx-dataset-expansion/SKILL.md
+++ b/plugin/skills/autoctx-dataset-expansion/SKILL.md
@@ -101,7 +101,7 @@ Use the following internal tracking format per generated candidate (not written 
 
 **Goal:** Reword the NLQ into a semantically equivalent question while keeping the SQL 100% unchanged.
 
-**When to apply:** Any pair in the source dataset. Highly recommended for pairs with `complexity: low` or `complexity: medium` as they have simpler, more universally rephrashable NLQs.
+**When to apply:** Any pair in the source dataset. Highly recommended for pairs with `complexity: low` or `complexity: medium` as they have simpler, more universally rephraseable NLQs.
 
 **Execution steps:**
 1. Read the source NLQ.

--- a/plugin/skills/autoctx-dataset-expansion/SKILL.md
+++ b/plugin/skills/autoctx-dataset-expansion/SKILL.md
@@ -1,24 +1,50 @@
 ---
 name: autoctx-dataset-expansion
-description: "Expands an existing NLQ/SQL evaluation dataset using six structural variation strategies: paraphrasing, merging, difficulty adjustment, distraction injection, linguistic variation, and value substitution. Can be invoked standalone or from within other skills (e.g., the Expansion phase of autoctx-dataset-generation)."
+description: "Expands an existing NLQ/SQL evaluation dataset using six structural variation strategies: paraphrasing, merging, difficulty adjustment, distraction injection, linguistic variation, and value substitution. Can be invoked standalone or from within other skills (e.g., Phase 4 of autoctx-dataset-generation)."
 ---
 
 # Auto Context Generation - Dataset Expansion Workflow
 
-This skill expands an existing NLQ/SQL evaluation dataset by applying targeted variation strategies to existing pairs. The goal is to increase dataset size, diversity, and robustness without requiring additional schema analysis or business context collection from scratch.
+You are a Dataset Expansion specialist operating under a **state-driven, tool-verified, gated workflow**. Your goal is to expand an existing NLQ/SQL evaluation dataset by applying targeted variation strategies to existing pairs — increasing size, diversity, and robustness without requiring full business context re-acquisition.
 
 > [!IMPORTANT]
-> **Prerequisite**: An existing source dataset (JSON file) in the [Standard Dataset Format](#standard-dataset-format) is required before this skill can operate. If no dataset exists yet, use the `autoctx-dataset-generation` skill first.
+> **Prerequisite**: An existing source dataset (JSON file) in the [Standard Dataset Format](#standard-dataset-format) is required. If no dataset exists yet, run `autoctx-dataset-generation` first.
+
+## Core Operating Principles
+
+1.  **Phase Discipline:** Complete the Exit Criteria of one phase before moving to the next. Do not bundle multiple phases into a single turn.
+2.  **The Validation Lock (Mandatory):** You are **STRICTLY FORBIDDEN** from writing any expanded pair with `generate_dataset` until its SQL has been executed via `<source>-execute-sql` and verified logically sound.
+3.  **State Awareness:** Every response MUST begin with a **Phase Status** block (see below).
+4.  **Hard Gating:** Phases marked `[GATE: USER_APPROVAL]` require explicit user permission before executing.
+5.  **Deliverable Persistence:** All artifacts (plan, reports) MUST be written to the file system — never only summarized in chat.
+6.  **Deterministic SQL:** Any expanded SQL using `LIMIT`, window functions, or ranking MUST include a tie-breaking `ORDER BY` clause.
+7.  **Semantic Bridge:** NLQs use natural business vocabulary; SQL uses the exact technical schema. Never leak raw column names into NLQs.
+
+---
+
+## The Phase Status Block
+
+Prepend this block to **every single response**:
+
+```text
+### Phase Status
+- **Current Phase:** [Phase Number: Name]
+- **Deliverables:** [Files written / actions taken this turn]
+- **Validation Source:** [Database name used for execution, or N/A]
+- **Gate Status:** [LOCKED (Awaiting Approval) | OPEN (Executing)]
+```
+
+---
 
 ## Input
 
-Before beginning the workflow, you explicitly require:
+Before beginning, confirm:
 
-- **Source dataset path**: Absolute path to the existing `golden.json` (or equivalent) in the Standard Dataset Format.
-- **Output file path**: Absolute path where expanded pairs should be written or appended. May be the same as the source file.
-- **Active `tools.yaml`** (located in `autoctx/`): Required for value substitution (Phase 3, Strategy 6) and for SQL execution validation (Phase 4). If `tools.yaml` is not present, value substitution will be skipped and SQL execution validation will be degraded to syntax-only checking — warn the user.
-- **Expansion strategies to apply** (ask the user): One or more of the six strategies listed below. Default to all six if the user has no preference.
-- **Target pair count or multiplier**: Either a fixed number of new pairs to generate (e.g., "add 20 pairs") or a multiplier on the source dataset (e.g., "2x the dataset"). Default to generating at minimum 1 expansion per source pair if unspecified.
+- **Source dataset**: The existing `golden.json` (or equivalent) filename.
+- **Output file**: Filename where expanded pairs will be written/appended. May be the same as source.
+- **Active `tools.yaml`** (in `autoctx/`): Required for Value Substitution (Strategy 6) and SQL execution validation. If missing, skip Strategy 6 and warn the user that execution validation is degraded.
+- **Expansion strategies**: One or more of the six strategies. Default to all six if unspecified.
+- **Target count or multiplier**: Fixed number (e.g., "add 20") or multiplier (e.g., "2x"). Default to at least 1 variant per source pair.
 
 ## Workflow
 
@@ -52,45 +78,44 @@ Follow these steps exactly in order:
 
 ---
 
-### Phase 2: Expansion Planning
+### Phase 2: Expansion Planning `[GATE: USER_APPROVAL]`
 
-Before generating any pairs, analyze the source dataset and produce a formal **Expansion Plan**.
+Analyze the source dataset and produce a formal **Expansion Plan**. Write it to `evalset_expansion_plan.md`.
 
 The plan must cover:
 
 1. **Source Dataset Analysis:**
-   - Complexity distribution: how many pairs are tagged `low`, `medium`, `high` (or estimate if tags are absent).
-   - Topic/domain coverage: which business themes appear.
-   - SQL feature coverage: what SQL constructs are already present (simple SELECTs, JOINs, aggregations, CTEs, subqueries, window functions, etc.).
-   - Pairs eligible for each strategy (e.g., only pairs with literal values in the NLQ are candidates for Value Substitution; only pairs that share related tables are candidates for Merging).
+   - Complexity distribution (low/medium/high) from tags, or estimated if absent.
+   - Topic/domain coverage and SQL feature inventory (SELECTs, JOINs, aggregations, CTEs, window functions).
+   - Eligibility per strategy: which source pairs can be targeted by each strategy (e.g., only pairs with literal values in the NLQ qualify for Value Substitution).
 
 2. **Strategy Allocation:**
-   - How many new pairs will each strategy contribute to reach the target count.
-   - Which source pairs are assigned to which strategies (can be approximate at this stage).
-   - Prioritize strategies that fill identified gaps (e.g., if the source dataset has no `high`-complexity pairs, prioritize Merging and Difficulty Upscaling).
+   - How many new pairs each strategy will contribute toward the target count.
+   - Prioritize strategies that fill identified coverage gaps (e.g., if no `high`-complexity pairs exist, prioritize Merging and Upscaling).
+   - Reference `references/expansion-strategies.md` for detailed per-strategy execution rules.
 
 3. **Target Complexity Distribution:**
-   - Define the desired complexity distribution across all new pairs (e.g., 30% low, 40% medium, 30% high). Try to maintain or improve the distribution of the source dataset unless the user specifies otherwise.
+   - Desired breakdown across new pairs (e.g., 30% low / 40% medium / 30% high).
+   - Justify any deviation from the source dataset's distribution.
 
-4. **Value Substitution Column Targets:**
-   - For pairs containing literal values, identify which column(s) to run `SELECT DISTINCT` on for candidate replacement values.
+4. **Value Substitution Column Targets** (if Strategy 6 is active):
+   - List column(s) to run `SELECT DISTINCT` on and the source pairs targeted.
 
-5. **Validation Criteria:**
-   - All expanded SQL must be executable against the live database (if `tools.yaml` is available).
-   - All expanded pairs must pass the **Blind Test** (another agent could reconstruct the SQL from only the NLQ and business context).
-   - Pairs whose SQL returns 0 rows will be flagged but not automatically dropped — the user will decide.
-   - Pairs failing execution will be dropped automatically.
+5. **Sampling Proposal:**
+   - Based on the source dataset size and target count, proactively recommend a final sample size if the total dataset would exceed 50 pairs (e.g., "The combined dataset will have 64 pairs — I recommend sampling to 40 for evaluation efficiency").
+   - Explain the proposed sample size with justification (coverage, diversity, budget).
+   - The user may override the proposed sample size or skip sampling.
 
 > [!IMPORTANT]
-> **Always present the Expansion Plan to the user for confirmation or edits before proceeding to Phase 3.** Save the approved plan to `./evalset_states/plans/eval_dataset_expansion_plan.md` (create the directory if needed).
+> **[STOP]** Present this plan to the user and wait for explicit approval before proceeding to Phase 3. Do NOT generate any pairs yet.
 
 ---
 
-### Phase 3: Expansion Execution
+### Phase 3: Expansion Execution & Validation Gate
 
-Apply each approved strategy using the source pairs identified in the plan. For every generated pair, execute the internal **Chain of Thought** described in each strategy below, then apply the [Cross-Strategy Validation Rules](#cross-strategy-validation-rules).
+Read `references/expansion-strategies.md` for detailed per-strategy rules before generating. Apply each approved strategy using the source pairs identified in the plan.
 
-Use the following internal tracking format per generated candidate (not written to the output file — internal reasoning only):
+Use the following internal tracking per candidate (not written to disk — internal reasoning only):
 - `source_id`: the `id` of the source pair(s)
 - `strategy`: which strategy produced this candidate
 - `status`: `pending_validation` | `approved` | `dropped`
@@ -245,42 +270,35 @@ Use the following internal tracking format per generated candidate (not written 
 
 ---
 
-### Cross-Strategy Validation Rules
+#### The Validation Gate (Mandatory — End of Phase 3)
 
-Apply these rules to every candidate pair, regardless of strategy, before marking it `approved`:
+After generating all candidates, apply these rules to every pair before moving to Phase 4. Consult `references/acceptance-criteria.md` for the full acceptance criteria.
 
-1. **SQL Execution (if `tools.yaml` available):**
-   - Execute the `golden_sql` via `<source>-execute-sql`.
-   - If execution throws an error → mark `dropped`. Log the error in the validation report.
-   - If execution returns 0 rows → mark `flagged:empty_result`. Do NOT auto-drop. Report to user and wait for instruction.
-   - If execution returns rows → mark `approved` (subject to Blind Test below).
+1. **SQL Execution** (required if `tools.yaml` available):
+   - Execute each `golden_sql` via `<source>-execute-sql`.
+   - Error → mark `dropped`. Log error.
+   - 0 rows → mark `flagged:empty_result`. Do NOT auto-drop — report to user.
+   - Rows returned → proceed to Blind Test.
 
-2. **Blind Test:**
-   - Look only at the new NLQ (and the database name/domain). Could another agent unambiguously produce the exact `golden_sql`?
-   - If the NLQ is too vague, ambiguous, or inconsistent with the SQL → refine the NLQ or mark `dropped`.
+2. **Blind Test & Semantic Bridge:**
+   - Could another agent produce the exact SQL from only the NLQ + domain context? If ambiguous → refine or mark `dropped`.
+   - NLQ must use business vocabulary, not raw column names.
 
-3. **Schema Fidelity:**
-   - No invented table names or column names in `golden_sql`.
-   - All column references exist in the schema (cross-check if schema was fetched in Phase 1).
+3. **Schema Fidelity & Determinism:**
+   - No invented table or column names.
+   - Any `LIMIT` or ranking query must include a tie-breaking `ORDER BY`.
 
-4. **No Duplication:**
-   - Check the output file for near-identical NLQs. Do not add pairs that are trivially identical to an already-existing pair.
-
-5. **Semantic Bridge:**
-   - The NLQ must use business vocabulary, not raw SQL column/table names (e.g., NLQ should say "region" not `A3`, "issuance frequency" not `frequency`). Exception: if the column name is itself a natural business term.
+4. **No Duplication:** Do not produce pairs trivially identical to an existing pair in the output file.
 
 ---
 
-### Phase 4: Validation Report
+### Phase 4: Audit & Reporting `[GATE: USER_APPROVAL]`
 
-After all candidates have been processed through Cross-Strategy Validation, generate a two-tier validation report.
+Consult `references/review-protocol.md` for full audit criteria. Generate two reports:
 
-> [!IMPORTANT]
-> **Present the validation report plan to the user for confirmation before writing the reports.** Save the approved review plan to `./evalset_states/plans/eval_dataset_expansion_review_plan.md`.
+**Deliverable 1 — `evalset_expansion_report_pair_level.md`:**
 
-**Tier 1 — Pair-Level Review:**
-
-For every candidate pair (approved, dropped, and flagged), produce a structured entry:
+For every candidate (approved, dropped, flagged):
 
 ```markdown
 ### Pair: <new_id> (from <source_id> via <strategy>)
@@ -288,79 +306,69 @@ For every candidate pair (approved, dropped, and flagged), produce a structured 
 - **NLQ**: "<the NLQ>"
 - **SQL**: `<the golden_sql>`
 - **Execution Result**: Returned N rows | Error: <message> | 0 rows (flagged)
-- **Blind Test**: Pass | Fail — <reason if fail>
-- **Drop/Flag Reason**: <if applicable>
+- **Blind Test**: Pass | Fail — <reason>
 - **Complexity**: low | medium | high
-- **Topic**: <business domain>
+- **Grounding Citation**: <source file / DB / schema snippet>
 ```
 
-Save to `./evalset_states/reports/eval-dataset-expansion-review-pair-level.md`.
-
-**Tier 2 — Dataset-Level Summary:**
-
-Aggregate across all approved pairs:
+**Deliverable 2 — `evalset_expansion_report_dataset_level.md`:**
 
 ```markdown
-# Dataset Expansion Summary
+# Dataset Expansion Audit Summary
 
 ## Source Dataset
-- Total source pairs: N
-- Databases: [list]
+- Total source pairs: N  |  Databases: [list]
 
 ## Expansion Results
 | Strategy             | Candidates | Approved | Dropped | Flagged (0 rows) |
-|----------------------|------------|----------|---------|-----------------|
-| Paraphrase           | X          | X        | X       | X               |
-| Merge                | X          | X        | X       | X               |
-| Difficulty Adjust    | X          | X        | X       | X               |
-| Distraction          | X          | X        | X       | X               |
-| Linguistic Variation | X          | X        | X       | X               |
-| Value Substitution   | X          | X        | X       | X               |
-| **Total**            | **X**      | **X**    | **X**   | **X**           |
+|----------------------|------------|----------|---------|------------------|
+| Paraphrase           | X          | X        | X       | X                |
+| Merge                | X          | X        | X       | X                |
+| Difficulty Adjust    | X          | X        | X       | X                |
+| Distraction          | X          | X        | X       | X                |
+| Linguistic Variation | X          | X        | X       | X                |
+| Value Substitution   | X          | X        | X       | X                |
+| **Total**            | **X**      | **X**    | **X**   | **X**            |
 
 ## Complexity Distribution (Approved Pairs)
-- Low: X (X%)
-- Medium: X (X%)
-- High: X (X%)
+- Low: X (X%)  |  Medium: X (X%)  |  High: X (X%)
 
-## SQL Feature Coverage (Approved Pairs)
-- Simple SELECT: X
-- Aggregation (COUNT, SUM, AVG): X
-- JOINs: X
-- GROUP BY / HAVING: X
-- Subqueries / CTEs: X
-- Window Functions: X
+## SQL Taxonomy Coverage
+- Aggregation: X  |  JOINs: X  |  GROUP BY/HAVING: X  |  CTEs/Subqueries: X  |  Window Functions: X
 
-## Topics Covered
-<list of distinct topic tags>
+## Gap Analysis
+<SQL patterns or topics not yet covered; recommended targets for next expansion>
 ```
 
-Save to `./evalset_states/reports/eval-dataset-expansion-review-dataset-level.md`.
-
-Present both reports to the user. Wait for their confirmation (and any manual overrides for flagged pairs) before writing to the output file.
+> [!IMPORTANT]
+> **[STOP]** Present both reports to the user. Wait for explicit approval and any overrides for `flagged:empty_result` pairs before writing to the output file.
 
 ---
 
-### Phase 5: Output
+### Phase 5: Finalization & Sampling
 
-1. **Apply User Overrides:** If the user manually approved any `flagged:empty_result` pairs or restored any dropped pairs, update their status to `approved`.
+1. **Apply User Overrides:** Apply any `flagged:empty_result` approvals or manual restorations from Phase 4.
 
-2. **Write Approved Pairs:** Use the `generate_dataset` MCP tool to append all `approved` pairs to the output file path. Always use the **absolute path**. Pairs must conform to the Standard Dataset Format.
+2. **Write Approved Pairs:** Use the `generate_dataset` MCP tool to append all `approved` pairs to the output file. If the file exists, merge intelligently without `golden_sql` duplication. Provide the exact output filename.
 
-3. **Assign Tags:** Every expanded pair must include:
+3. **Required Tags per Pair:**
    - `"complexity: <low|medium|high>"`
    - `"topic: <business_domain>"`
    - `"source: expansion:<strategy_name>"` (e.g., `"source: expansion:paraphrase"`)
-   - `"expansion_source_id: <source_pair_id>"` (for single-source strategies)
-   - `"expansion_source_ids: [<id1>, <id2>]"` (for Merge strategy only)
-   - Where applicable: `"substituted_column: <table>.<column>"` (Value Substitution only)
+   - `"is_expanded: true"`
+   - `"expansion_source_id: <source_pair_id>"` (single-source strategies)
+   - `"expansion_source_ids: [<id1>, <id2>]"` (Merge strategy only)
+   - `"substituted_column: <table>.<column>"` (Value Substitution only)
 
-4. **Final Summary:** Report to the user:
-   - Total approved pairs written.
-   - Breakdown by strategy.
-   - Final combined dataset size (original + new).
-   - Exact output file path.
-   - Suggest next step: run evaluation using the `autoctx-evaluate` skill on the expanded dataset.
+4. **Diversity Sampling** (if proposed in Phase 2 plan and approved):
+   - If the combined dataset exceeds the approved sample target, intelligently sample to maximize structural, topical, and complexity diversity.
+   - Save the sample to `[original_filename]_sample_[count].json` (e.g., `golden_sample_40.json`).
+
+5. **Final Summary:** Report:
+   - Total approved pairs written and breakdown by strategy.
+   - Final combined dataset size (original + expanded).
+   - Sample file path if sampling was performed.
+   - Suggest next step: `autoctx-evaluate` to score the expanded dataset.
 
 ---
 
@@ -389,12 +397,13 @@ All input and output files must use this JSON schema:
 - **`complexity`**: `"low"` (single table, no aggregation), `"medium"` (multi-table JOIN or aggregation), `"high"` (CTEs, subqueries, window functions, multi-condition logic).
 - **`topic`**: Business domain or analytical theme (e.g., `"loan_eligibility"`, `"account_activity"`, `"regional_distribution"`).
 - **`source`**: Must include the prefix `"expansion:"` followed by the strategy name for all pairs generated by this skill.
-- **`expansion_source_id`** / **`expansion_source_ids`**: Traceability back to the original pair(s).
+- **`is_expanded`**: Always `true` for pairs produced by this skill.
+- **`expansion_source_id`** / **`expansion_source_ids`**: Traceability back to the originating pair(s).
 
 ## Interaction Guidelines
 
-- **Confirm at every gate:** This skill has two mandatory user confirmation gates — after presenting the Expansion Plan (Phase 2) and after presenting the Validation Reports (Phase 4). Do not skip these.
-- **Be transparent about drops:** Always report exactly why a candidate was dropped — SQL execution error, Blind Test failure, or schema violation.
-- **Batch efficiently:** When running SQL execution for validation, batch `<source>-execute-sql` calls efficiently rather than one at a time where the tooling supports it.
-- **Respect the source dataset's domain:** Do not generate NLQs that venture into business domains not reflected in the source dataset unless the user explicitly requests broadening the scope.
-- **Do not over-expand:** Avoid creating so many near-identical variants of a single pair that the dataset becomes repetitive. Aim for diversity first.
+- **Two hard gates:** Phase 2 (plan approval) and Phase 4 (audit approval). Never skip them.
+- **Transparent drops:** Always state why a candidate was dropped — execution error, Blind Test failure, or schema violation.
+- **Batch SQL calls efficiently** rather than one at a time.
+- **Respect the source domain:** Do not introduce NLQ topics not present in the source dataset without explicit user request.
+- **Diversity over volume:** Avoid near-identical variants of the same pair. One strong, distinct variant beats three trivial ones.

--- a/plugin/skills/autoctx-dataset-expansion/references/expansion-strategies.md
+++ b/plugin/skills/autoctx-dataset-expansion/references/expansion-strategies.md
@@ -1,0 +1,141 @@
+# Dataset Expansion Strategies
+
+This document defines the six expansion strategies used by the `autoctx-dataset-expansion` skill. For every generated pair, use the Chain of Thought below regardless of strategy, then apply the **Validation Gate** defined in the main skill.
+
+## Chain of Thought (All Strategies)
+
+For every candidate:
+1. **Draft SQL (Schema-First):** Write syntactically correct, dialect-compliant SQL. Use only columns and tables confirmed in the schema. Ensure any `LIMIT` or window function includes a tie-breaking `ORDER BY`.
+2. **Literal Translation:** Translate the SQL literally into English to surface all logical constraints.
+3. **Humanize & Bridge:** Rewrite into natural business language. Never leak raw column names into the NLQ.
+4. **Blind Test:** Looking only at the NLQ and business context — could another agent produce the exact SQL? If ambiguous, refine or discard.
+
+---
+
+## Strategy 1: Paraphrasing
+
+**Goal:** Reword the NLQ into a semantically equivalent question while keeping the `golden_sql` 100% unchanged.
+
+**When to apply:** Any pair. Especially effective for `complexity: low` or `complexity: medium` pairs where the NLQ is straightforwardly rephraseable.
+
+**Execution:**
+1. Generate 1–3 NLQ variants that:
+   - Change sentence structure (question → imperative, formal → informal, verbose → concise).
+   - Replace business terms with unambiguous synonyms (e.g., "accounts" → "customers").
+   - Vary perspective ("How many X?" → "Give me the count of X" → "What is the total number of X?").
+2. Do NOT change `golden_sql`.
+3. Apply the Blind Test. Discard any variant that loses precision (drops a key filter condition).
+4. Tag: `"source: expansion:paraphrase"`.
+
+**Anti-pattern:** Do not create a paraphrase so vague that it could map to a different SQL (e.g., dropping the region filter from a region-specific question).
+
+---
+
+## Strategy 2: Merging
+
+**Goal:** Combine two or more source pairs into a single, more sophisticated NLQ/SQL pair using subqueries, CTEs, or compound conditions.
+
+**When to apply:** Source pairs that share at least one common table or concept. Do NOT merge pairs from different databases.
+
+**Execution:**
+1. Identify 2–3 logically composable source pairs.
+2. Draft the merged SQL first (schema-first):
+   - Use a CTE, subquery, or compound WHERE clause.
+   - Verify all table references and join conditions.
+3. Humanize the merged SQL into a natural NLQ following the Semantic Bridge principle.
+4. Apply the Blind Test.
+5. Set `complexity` tag to at least one level higher than the highest-complexity source pair.
+6. Tags: `"source: expansion:merge"`, `"expansion_source_ids: [eval_001, eval_002]"`.
+
+**Anti-pattern:** Do not build "Frankenstein" queries with 5+ joins unless explicitly asked for a `complexity: high` pair.
+
+---
+
+## Strategy 3: Difficulty Adjustment
+
+**Goal:** Create a simpler or more sophisticated variant by adding or removing SQL constructs.
+
+**When to apply:**
+- **Simplification (Downscale):** Source pairs with `complexity: medium` or `complexity: high`.
+- **Sophistication (Upscale):** Source pairs with `complexity: low` or `complexity: medium`.
+
+**Execution — Simplification:**
+1. Remove one construct: a JOIN, aggregation, subquery, window function, or a specific WHERE condition.
+2. Rewrite the SQL with the construct removed (result must still be valid and meaningful).
+3. Adjust the NLQ to accurately reflect the simplified question.
+4. Reduce the `complexity` tag accordingly.
+5. Tag: `"source: expansion:simplify"`.
+
+**Execution — Sophistication (Upscaling):**
+1. Add a meaningful construct: `GROUP BY` + aggregation, CTE conversion, `HAVING` clause, ranking window function (`ROW_NUMBER`, `RANK`), additional JOIN to a related table, or a date/range filter.
+2. Draft the enriched SQL (schema-first). Confirm all new column/table references exist.
+3. Update the NLQ to accurately reflect the added complexity.
+4. Increase the `complexity` tag accordingly.
+5. Tag: `"source: expansion:upscale"`.
+
+**Anti-pattern (Upscaling):** Do not add complexity for its own sake. The added construct must serve a realistic business question.
+
+---
+
+## Strategy 4: Distraction Injection
+
+**Goal:** Add misleading or irrelevant information to the NLQ that does NOT change the SQL. Tests whether the Data Agent can filter noise.
+
+**When to apply:** Any pair. Prefer `complexity: low` or `complexity: medium` where the noise is clearly extraneous.
+
+**Distraction types (choose one per variant):**
+- **Irrelevant entity mention:** Reference a table/concept not part of the SQL (e.g., "I looked at the transactions table but what I need is...").
+- **Redundant condition:** Add a condition always true or subsumed by an existing filter.
+- **Out-of-scope qualifier:** Add a time/status qualifier that sounds meaningful but maps to no schema column (only use if the column genuinely does not exist — never invent filters).
+- **Conversational filler:** Add preamble like "I was wondering...", "For a report I'm building...", "Can you help me find...".
+
+**Execution:**
+1. Choose one distraction type.
+2. Inject into the NLQ only. `golden_sql` must be bit-for-bit identical.
+3. Apply the Blind Test with extra scrutiny: the distraction must NOT cause ambiguity about which SQL to produce.
+4. Tag: `"source: expansion:distraction"`.
+
+---
+
+## Strategy 5: Linguistic Variation
+
+**Goal:** Introduce realistic linguistic noise — typos, synonyms, acronyms, informal phrasing — that a real user might type.
+
+**When to apply:** Any pair. Apply sparingly — maximum 1–2 variants per source pair. Do NOT combine with Distraction on the same pair.
+
+**Variation types (apply one or two per variant):**
+- **Typos:** 1–2 plausible typing errors (e.g., `"acocunts"`, `"hwo many"`). Do NOT typo values that map to SQL literals, as this makes the Blind Test ambiguous.
+- **Synonyms:** Replace business terms (e.g., "clients" → "customers", "loan" → "credit", "region" → "area").
+- **Acronyms:** Use domain acronyms where plausible (e.g., "year to date" → "YTD", "month over month" → "MoM").
+- **Informal phrasing:** Contractions or casual language (e.g., "what's" instead of "what is", "show me" instead of "retrieve").
+
+**Execution:**
+1. Apply chosen variation(s) to the NLQ. `golden_sql` must be unchanged.
+2. Apply the Blind Test: despite the noise, would a skilled agent produce the correct SQL?
+3. Tag: `"source: expansion:linguistic"`.
+
+---
+
+## Strategy 6: Value Substitution
+
+**Goal:** Replace a literal value in the NLQ and its corresponding SQL WHERE clause with a different real value from the same column. Generates structurally identical pairs with different parameters.
+
+**When to apply:** Pairs that contain a literal string or numeric value in both the NLQ and the SQL WHERE clause. Requires a live database connection (`tools.yaml`). If unavailable, skip this strategy.
+
+**Execution:**
+1. Identify the literal value(s) in the NLQ that map to SQL WHERE clause literals.
+2. Determine the source table and column (e.g., `district.A3 = 'Prague'` → table `district`, column `A3`).
+3. **Run value discovery:**
+   ```sql
+   SELECT DISTINCT "<column>" FROM "<table>" WHERE "<column>" IS NOT NULL ORDER BY 1 LIMIT 20;
+   ```
+4. Remove the source value from the candidate list. Select 1–3 alternatives.
+5. For each alternative:
+   - Replace the literal in `golden_sql`.
+   - Replace the term in the NLQ (use the actual value or a natural equivalent).
+   - Run the substituted SQL via `<source>-execute-sql`.
+   - 0 rows → flag with `"result: empty_result"`.
+   - Apply the Blind Test.
+6. Tags: `"source: expansion:value_substitution"`, `"substituted_column: <table>.<column>"`.
+
+**Anti-pattern:** Do not count changing `region = 'East'` to `region = 'West'` without also verifying the new value actually exists in the database and the query returns rows.

--- a/plugin/skills/autoctx-dataset-generation/SKILL.md
+++ b/plugin/skills/autoctx-dataset-generation/SKILL.md
@@ -65,7 +65,9 @@ You must prepend this exact block to the very top of **every single response** y
 *   **Goal:** Increase volume and edge-case coverage.
 *   **Mandatory Actions:**
     1.  Read `references/expansion-guideline.md`.
-    2.  Generate variations (Entity substitution, Temporal shifts, Logic inversion) following the **Validation Protocol** (Execute before Save).
+    2.  There are two paths — ask the user which they want if not already specified:
+        - **Net-new pairs from context** (schema, docs, query logs): Generate additional pairs following the Strategic Plan from Phase 2, applying the Validation Protocol (Execute before Save).
+        - **Structural variations of existing pairs**: **Invoke the `autoctx-dataset-expansion` skill.** This skill handles all variation-based strategies (paraphrasing, merging, difficulty adjustment, distraction injection, linguistic variation, and value substitution), including SQL execution validation and audit reporting.
 
 ### **PHASE 5: AUDIT & REPORTING**
 *   **Goal:** Verify health and diversity.

--- a/plugin/skills/autoctx-dataset-generation/SKILL.md
+++ b/plugin/skills/autoctx-dataset-generation/SKILL.md
@@ -61,13 +61,17 @@ You must prepend this exact block to the very top of **every single response** y
         - **Verify:** If execution fails or results are logically impossible, refine the SQL and retry.
 *   **Rule:** For every pair generated, you must state: *"Verified eval_XXX against [Source Name]."*
 
-### **PHASE 4: EXPANSION & DIVERSIFICATION**
+### **PHASE 4: EXPANSION & DIVERSIFICATION [GATE: USER_APPROVAL]**
 *   **Goal:** Increase volume and edge-case coverage.
 *   **Mandatory Actions:**
     1.  Read `references/expansion-guideline.md`.
-    2.  There are two paths — ask the user which they want if not already specified:
-        - **Net-new pairs from context** (schema, docs, query logs): Generate additional pairs following the Strategic Plan from Phase 2, applying the Validation Protocol (Execute before Save).
-        - **Structural variations of existing pairs**: **Invoke the `autoctx-dataset-expansion` skill.** This skill handles all variation-based strategies (paraphrasing, merging, difficulty adjustment, distraction injection, linguistic variation, and value substitution), including SQL execution validation and audit reporting.
+    2.  **ALWAYS** present the two paths below to the user and require an explicit choice before doing any work. Do NOT infer a path from the prior conversation:
+
+        **Option A — Net-new pairs from context** (schema, docs, query logs): Generate additional pairs following the Strategic Plan from Phase 2, applying the Validation Protocol (Execute before Save). Execute this path inline in the current skill.
+
+        **Option B — Structural variations of existing pairs** (paraphrasing, merging, difficulty adjustment, distraction injection, linguistic variation, value substitution): You **MUST NOT** execute these strategies inline. Instead, tell the user: *"Please re-invoke the `autoctx-dataset-expansion` skill for this task. That skill owns all variation-based expansion workflows."* Then stop and wait.
+
+    3.  After the user selects **Option A**, proceed with net-new generation. **Option B terminates this phase** — the work continues in the `autoctx-dataset-expansion` skill.
 
 ### **PHASE 5: AUDIT & REPORTING**
 *   **Goal:** Verify health and diversity.


### PR DESCRIPTION
feat: add autoctx-dataset-expansion skill and evaluation coverage

Introduces a new standalone skill for expanding existing NLQ/SQL
evaluation datasets through six structural variation strategies:
paraphrasing, merging, difficulty adjustment (upscale/simplify),
distraction injection, linguistic variation (typos/synonyms/acronyms),
and value substitution (via SELECT DISTINCT on target columns).

The skill follows the established autoctx workflow pattern with two
mandatory human-in-the-loop confirmation gates (expansion plan +
validation report), SQL execution validation against the live database,
and a two-tier validation report (pair-level + dataset-level). All
expanded pairs receive traceability tags (expansion_source_id, strategy,
substituted_column) and inherit the standard dataset format.

Changes:

skills/autoctx-dataset-expansion/SKILL.md: new skill (all locations
via hardlink)
skills/autoctx-dataset-generation/SKILL.md: Phase 5 updated to
delegate variation-based expansion to autoctx-dataset-expansion;
net-new context-grounded generation remains inline
evals/core-cujs/dataset.json: insert autoctx-dataset-expansion CUJ
(max_turns: 8) between dataset-generation and bootstrap; update
autoctx-bootstrap work_dir to workspace_post_expansion/
evals/core-cujs/workspace_post_expansion/: new pre-baked workspace
with expanded golden.json (12 pairs covering all 6 strategies) and
autoctx/ scaffold
evals/smoke-test/dataset.json: add autoctx-dataset-expansion to
expected skill list