### PR TITLE
ci: upload eval results to BigQuery with extension/version tags

### DIFF
--- a/.ci/cloudbuild.yaml
+++ b/.ci/cloudbuild.yaml
@@ -30,6 +30,8 @@ steps:
           echo "No PR number provided. Assuming local/manual run — enabling all evals."
           touch /workspace/SHOULD_RUN_GEMINI_CLI
           touch /workspace/SHOULD_RUN_CLAUDE_CODE
+          # Release version for BQ reporting on manual/local runs.
+          printf '%s' "manual-$BUILD_ID" > /workspace/RELEASE_VERSION
           exit 0
         fi
 
@@ -42,6 +44,23 @@ steps:
           cat pr_data.json
           exit 1
         fi
+
+        # Derive the release version recorded alongside eval results in BigQuery.
+        # Release-please PRs carry the cut version in their title; other PRs are
+        # tagged with the PR number for traceability. Written to a marker file
+        # so the per-suite run scripts can pick it up.
+        PR_TITLE=$(jq -r '.title' pr_data.json)
+        if [[ "$_HEAD_BRANCH" == release-please-* ]]; then
+          if [[ "$$PR_TITLE" =~ release\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            RELEASE_VERSION="$${BASH_REMATCH[1]}"
+          else
+            RELEASE_VERSION="pr-$_PR_NUMBER-release-unknown"
+          fi
+        else
+          RELEASE_VERSION="pr-$_PR_NUMBER-ci-run-evals"
+        fi
+        echo "Release version: $$RELEASE_VERSION"
+        printf '%s' "$$RELEASE_VERSION" > /workspace/RELEASE_VERSION
 
         if jq -e '.labels | any(.name == "ci:eval-gemini")' pr_data.json > /dev/null; then
           echo "ci:eval label detected — enabling Gemini CLI evals."
@@ -67,6 +86,7 @@ steps:
     env:
       - 'EVAL_GCP_PROJECT_ID=$PROJECT_ID'
       - 'EVAL_GCP_PROJECT_REGION=$_PROJECT_LOCATION'
+      - 'EVAL_REPORTING_PROJECT=$_EVAL_REPORTING_PROJECT'
     args: ['.ci/run_gemini_cli.sh', 'smoke-test']
 
   - id: eval-claude-code-smoke-test
@@ -77,6 +97,7 @@ steps:
     env:
       - 'EVAL_GCP_PROJECT_ID=$PROJECT_ID'
       - 'EVAL_GCP_PROJECT_REGION=$_PROJECT_LOCATION'
+      - 'EVAL_REPORTING_PROJECT=$_EVAL_REPORTING_PROJECT'
       - 'CLAUDE_GCP_VERTEX_PROJECT_ID=$_CLAUDE_GCP_VERTEX_PROJECT_ID'
     args: ['.ci/run_claude_code.sh', 'smoke-test']
 
@@ -89,6 +110,7 @@ steps:
     env:
       - 'EVAL_GCP_PROJECT_ID=$PROJECT_ID'
       - 'EVAL_GCP_PROJECT_REGION=$_PROJECT_LOCATION'
+      - 'EVAL_REPORTING_PROJECT=$_EVAL_REPORTING_PROJECT'
     args: ['.ci/run_gemini_cli.sh', 'core-cujs']
 
   - id: eval-gemini-cli-freeform-input
@@ -99,6 +121,7 @@ steps:
     env:
       - 'EVAL_GCP_PROJECT_ID=$PROJECT_ID'
       - 'EVAL_GCP_PROJECT_REGION=$_PROJECT_LOCATION'
+      - 'EVAL_REPORTING_PROJECT=$_EVAL_REPORTING_PROJECT'
     args: ['.ci/run_gemini_cli.sh', 'freeform-input']
 
   # --- Claude Code eval steps (parallel, isolated per suite) ---
@@ -110,6 +133,7 @@ steps:
     env:
       - 'EVAL_GCP_PROJECT_ID=$PROJECT_ID'
       - 'EVAL_GCP_PROJECT_REGION=$_PROJECT_LOCATION'
+      - 'EVAL_REPORTING_PROJECT=$_EVAL_REPORTING_PROJECT'
       - 'CLAUDE_GCP_VERTEX_PROJECT_ID=$_CLAUDE_GCP_VERTEX_PROJECT_ID'
     args: ['.ci/run_claude_code.sh', 'core-cujs']
 
@@ -121,6 +145,7 @@ steps:
     env:
       - 'EVAL_GCP_PROJECT_ID=$PROJECT_ID'
       - 'EVAL_GCP_PROJECT_REGION=$_PROJECT_LOCATION'
+      - 'EVAL_REPORTING_PROJECT=$_EVAL_REPORTING_PROJECT'
       - 'CLAUDE_GCP_VERTEX_PROJECT_ID=$_CLAUDE_GCP_VERTEX_PROJECT_ID'
     args: ['.ci/run_claude_code.sh', 'freeform-input']
 
@@ -229,6 +254,10 @@ substitutions:
   # specific build; defaults to :latest.
   _EVALBENCH_IMAGE_TAG: 'latest'
   _PROJECT_LOCATION: 'global'
+  # GCP project whose `evalbench` BigQuery dataset receives eval results.
+  # Shared with the other cloud-db-nl2sql extensions; rows are distinguished
+  # by the extension_id / release_version fields from evals/ci_metadata.yaml.
+  _EVAL_REPORTING_PROJECT: 'cloud-db-nl2sql'
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/.ci/run_claude_code.sh
+++ b/.ci/run_claude_code.sh
@@ -40,6 +40,13 @@ sed -i "s|skills_dir: \"./dev-plugin\"|skills_dir: \"/workspace/dev-plugin\"|g" 
 # (kept out of the repo so the project ID isn't committed).
 sed -i "/^vertex_region:/a\\vertex_project_id: \"${CLAUDE_GCP_VERTEX_PROJECT_ID}\"" "model_configs/claude_code_model.yaml"
 
+# Append the runtime release_version and resolve the reporting-project
+# placeholder so evalbench's BigQuery reporter records them.
+RELEASE_VERSION="$(cat /workspace/RELEASE_VERSION 2>/dev/null || echo unknown)"
+CONFIG="${SUITE}/run_claude.yaml"
+printf '\nrelease_version: %s\n' "${RELEASE_VERSION}" >> "${CONFIG}"
+sed -i "s|\${EVAL_REPORTING_PROJECT}|${EVAL_REPORTING_PROJECT:-}|g" "${CONFIG}"
+
 # evalbench runtime
 export PYTHONPATH=/evalbench:/evalbench/evalproto
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python

--- a/.ci/run_gemini_cli.sh
+++ b/.ci/run_gemini_cli.sh
@@ -43,6 +43,13 @@ sed -i \
   -e "/^  GEMINI_MODEL:/a\\  GOOGLE_CLOUD_LOCATION: \"${EVAL_GCP_PROJECT_REGION}\"" \
   "model_configs/gemini_cli_model.yaml"
 
+# Append the runtime release_version and resolve the reporting-project
+# placeholder so evalbench's BigQuery reporter records them.
+RELEASE_VERSION="$(cat /workspace/RELEASE_VERSION 2>/dev/null || echo unknown)"
+CONFIG="${SUITE}/run_gemini_cli.yaml"
+printf '\nrelease_version: %s\n' "${RELEASE_VERSION}" >> "${CONFIG}"
+sed -i "s|\${EVAL_REPORTING_PROJECT}|${EVAL_REPORTING_PROJECT:-}|g" "${CONFIG}"
+
 # evalbench runtime
 export PYTHONPATH=/evalbench:/evalbench/evalproto
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python

--- a/evals/core-cujs/run_claude.yaml
+++ b/evals/core-cujs/run_claude.yaml
@@ -1,3 +1,6 @@
+# CI version-tracking metadata; release_version is appended at runtime by .ci.
+extension_id: db-context-enrichment
+
 ############################################################
 ### Dataset / Eval Items
 ############################################################
@@ -35,3 +38,5 @@ scorers:
 reporting:
   csv:
     output_directory: 'results'
+  bigquery:
+    gcp_project_id: "${EVAL_REPORTING_PROJECT}"

--- a/evals/core-cujs/run_gemini_cli.yaml
+++ b/evals/core-cujs/run_gemini_cli.yaml
@@ -1,3 +1,6 @@
+# CI version-tracking metadata; release_version is appended at runtime by .ci.
+extension_id: db-context-enrichment
+
 ############################################################
 ### Dataset / Eval Items
 ############################################################
@@ -32,3 +35,5 @@ scorers:
 reporting:
   csv:
     output_directory: 'results'
+  bigquery:
+    gcp_project_id: "${EVAL_REPORTING_PROJECT}"

--- a/evals/freeform-input/run_claude.yaml
+++ b/evals/freeform-input/run_claude.yaml
@@ -1,3 +1,6 @@
+# CI version-tracking metadata; release_version is appended at runtime by .ci.
+extension_id: db-context-enrichment
+
 ############################################################
 ### Dataset / Eval Items
 ############################################################
@@ -35,3 +38,5 @@ scorers:
 reporting:
   csv:
     output_directory: 'results'
+  bigquery:
+    gcp_project_id: "${EVAL_REPORTING_PROJECT}"

--- a/evals/freeform-input/run_gemini_cli.yaml
+++ b/evals/freeform-input/run_gemini_cli.yaml
@@ -1,3 +1,6 @@
+# CI version-tracking metadata; release_version is appended at runtime by .ci.
+extension_id: db-context-enrichment
+
 ############################################################
 ### Dataset / Eval Items
 ############################################################
@@ -32,3 +35,5 @@ scorers:
 reporting:
   csv:
     output_directory: 'results'
+  bigquery:
+    gcp_project_id: "${EVAL_REPORTING_PROJECT}"

--- a/evals/smoke-test/run_claude.yaml
+++ b/evals/smoke-test/run_claude.yaml
@@ -1,3 +1,6 @@
+# CI version-tracking metadata; release_version is appended at runtime by .ci.
+extension_id: db-context-enrichment
+
 ############################################################
 ### Dataset / Eval Items
 ############################################################
@@ -35,3 +38,5 @@ scorers:
 reporting:
   csv:
     output_directory: 'results'
+  bigquery:
+    gcp_project_id: "${EVAL_REPORTING_PROJECT}"

--- a/evals/smoke-test/run_gemini_cli.yaml
+++ b/evals/smoke-test/run_gemini_cli.yaml
@@ -1,3 +1,6 @@
+# CI version-tracking metadata; release_version is appended at runtime by .ci.
+extension_id: db-context-enrichment
+
 ############################################################
 ### Dataset / Eval Items
 ############################################################
@@ -32,3 +35,5 @@ scorers:
 reporting:
   csv:
     output_directory: 'results'
+  bigquery:
+    gcp_project_id: "${EVAL_REPORTING_PROJECT}"


### PR DESCRIPTION
## Summary
  Upload db-context-enrichment eval results to the shared
  `cloud-db-nl2sql.evalbench.*` BigQuery tables (same tables the other
  extensions report to), tagged with `extension_id` and `release_version`
  for per-extension / per-version tracking.

  ## Changes
  - **Run configs (all 6 suites):** add a `reporting.bigquery` reporter
    alongside the existing `csv` reporter (csv kept — the pass-rate gate
    reads `summary.csv`), and declare the static `extension_id:
    db-context-enrichment` top-level field.
  - **`.ci/cloudbuild.yaml`:** preflight derives `release_version`
    (release-please title → version, otherwise `pr-<n>-ci-run-evals`, or
    `manual-<build-id>`) and writes it to a `/workspace/RELEASE_VERSION`
    marker; new `_EVAL_REPORTING_PROJECT` substitution (default
    `cloud-db-nl2sql`) passed into each eval step as `EVAL_REPORTING_PROJECT`.
  - **`.ci/run_*.sh`:** append the runtime `release_version` onto the run
    config and resolve the `${EVAL_REPORTING_PROJECT}` placeholder.

  ## Notes
  - BigQuery upload runs for all suites, including the always-on smoke tests.
  - Requires the build service account (`crema-eval@cloud-db-nl2sql`) to have
    BigQuery write access on the `cloud-db-nl2sql.evalbench` dataset.

  ## Test plan
  - [ ] Open a PR with the `ci:eval-gemini` / `ci:eval-claude` label and
        confirm the build runs the gated suites.
  - [ ] Confirm rows land in `cloud-db-nl2sql.evalbench.*` with the expected
        `extension_id` and `release_version`.