### PR TITLE
chore(ci): migrate toolbox download to mcp-toolbox-for-databases buck…

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -23,8 +23,8 @@ EVALBENCH_VERSION=$(grep -o '^evalbench_version = "[^"]*"' pyproject.toml | cut 
 echo "Found toolbox version: ${TOOLBOX_VERSION}"
 echo "Found evalbench version: ${EVALBENCH_VERSION}"
 
-# 4. Download genai-toolbox binary (Linux amd64)
-DOWNLOAD_URL="https://storage.googleapis.com/genai-toolbox/v${TOOLBOX_VERSION}/linux/amd64/toolbox"
+# 4. Download mcp-toolbox binary (Linux amd64)
+DOWNLOAD_URL="https://storage.googleapis.com/mcp-toolbox-for-databases/v${TOOLBOX_VERSION}/linux/amd64/toolbox"
 echo "Downloading toolbox from: ${DOWNLOAD_URL}"
 curl -L --fail -o "toolbox" "${DOWNLOAD_URL}"
 chmod +x "toolbox"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      # Extract the targeted genai-toolbox version from pyproject.toml
+      # Extract the targeted mcp-toolbox version from pyproject.toml
       - name: Get Toolbox Version
         shell: bash
         run: |
@@ -73,11 +73,11 @@ jobs:
           echo "Found evalbench version: ${EVALBENCH_VERSION}"
           echo "EVALBENCH_VERSION=${EVALBENCH_VERSION}" >> $GITHUB_ENV
 
-      # Download the pre-compiled genai-toolbox binary for the target platform
-      - name: Download genai-toolbox binary
+      # Download the pre-compiled mcp-toolbox binary for the target platform
+      - name: Download mcp-toolbox binary
         shell: bash
         run: |
-          DOWNLOAD_URL="https://storage.googleapis.com/genai-toolbox/v${{ env.TOOLBOX_VERSION }}/${{ matrix.toolbox_os }}/${{ matrix.toolbox_arch }}/toolbox${{ matrix.toolbox_ext }}"
+          DOWNLOAD_URL="https://storage.googleapis.com/mcp-toolbox-for-databases/v${{ env.TOOLBOX_VERSION }}/${{ matrix.toolbox_os }}/${{ matrix.toolbox_arch }}/toolbox${{ matrix.toolbox_ext }}"
           echo "Downloading toolbox from: ${DOWNLOAD_URL}"
           curl -L --fail -o "toolbox${{ matrix.toolbox_ext }}" "${DOWNLOAD_URL}"
           chmod +x "toolbox${{ matrix.toolbox_ext }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
 ]
 
 [tool.db-context-engineering]
-toolbox_version = "0.31.0"
+toolbox_version = "1.4.0"
 evalbench_version = "1.7.1"
 
 [tool.ruff]


### PR DESCRIPTION
…et and bump to 1.4.0