### PR TITLE
chore: pin evalbench to 1.9.0 across pyproject and autoctx-evaluate skill

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -56,6 +56,21 @@ jobs:
             echo "::error file=$FILE::SKILL.md toolbox pin(s) don't match pyproject (expected $EXPECTED): $MISMATCHES"
             exit 1
           fi
+      - name: Check autoctx-evaluate SKILL.md evalbench pins match pyproject evalbench_version
+        run: |
+          set -euo pipefail
+          FILE=plugin/skills/autoctx-evaluate/SKILL.md
+          EXPECTED="google-evalbench==$(grep -o '^evalbench_version = "[^"]*"' pyproject.toml | cut -d '"' -f 2)"
+          FOUND=$(grep -oE 'google-evalbench==[0-9]+\.[0-9]+\.[0-9]+' "$FILE" | sort -u || true)
+          if [ -z "$FOUND" ]; then
+            echo "::error file=$FILE::no 'google-evalbench==X.Y.Z' pin found; SKILL.md must pin to $EXPECTED"
+            exit 1
+          fi
+          MISMATCHES=$(echo "$FOUND" | grep -v "^${EXPECTED}$" || true)
+          if [ -n "$MISMATCHES" ]; then
+            echo "::error file=$FILE::SKILL.md evalbench pin(s) don't match pyproject (expected $EXPECTED): $MISMATCHES"
+            exit 1
+          fi
 
   lint-and-format:
     runs-on: ubuntu-latest

--- a/plugin/skills/autoctx-evaluate/SKILL.md
+++ b/plugin/skills/autoctx-evaluate/SKILL.md
@@ -69,7 +69,7 @@ Follow these steps exactly in order:
 
 4. **Evalbench Run Integration:**
    - Trigger the `run_shell_command` natively to execute the evaluation from the ROOT of the workspace using the following exact command template:
-     `uvx google-evalbench --experiment_config=autoctx/experiments/<experiment_name>/eval_configs/run_config.yaml`
+     `uvx google-evalbench==1.9.0 --experiment_config=autoctx/experiments/<experiment_name>/eval_configs/run_config.yaml`
    - Check the command outputs to ensure the evaluation reports materialize in the respective `autoctx/experiments/<experiment_name>/eval_reports/` directory.
 
 ## Output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
 
 [tool.db-context-engineering]
 toolbox_version = "1.4.0"
-evalbench_version = "1.7.1"
+evalbench_version = "1.9.0"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
Pin the evalbench version across pyproject and the autoctx-evaluate skill, and bump from 1.7.1 → 1.9.0 now that both PyPI (`google-evalbench==1.9.0`) and the GitHub release binary (`linux.x64.evalbench.tar.gz`) are published. Mirrors the toolbox pinning pattern from #159: SKILL.md pins the `uvx google-evalbench==X.Y.Z` command, and a new presubmit guard enforces it matches `pyproject.toml`'s `evalbench_version`.
