### PR TITLE
ci: enforce conventional commit format on PR titles

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,36 @@
+name: Lint PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Must match the Conventional Commit types documented in CONTRIBUTING.md
+          # and accepted by Release-Please. Keep these three in sync.
+          types: |
+            feat
+            fix
+            perf
+            docs
+            refactor
+            test
+            build
+            ci
+            chore
+            revert
+            style
+          requireScope: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,11 @@ Examples:
 | **revert** | Reverting a previous commit. | none |
 | **style** | Formatting and whitespace only (rare with auto-formatters). | none |
 
-Only `feat`, `fix`, `perf`, and breaking changes (`!`) appear in the user-facing
-changelog by default; other types are accepted but hidden. Use `chore` or
-`refactor` for internal-only PRs you do not want announced in release notes.
+By default, only `feat`, `fix`, `perf`, and `revert` appear in the user-facing
+changelog; other types are accepted but hidden. Breaking changes always appear
+in their own top section regardless of the underlying type — even `chore!:` or
+`refactor!:` will be announced. Use `chore` or `refactor` (without `!`) for
+internal-only PRs you do not want surfaced in release notes.
 
 Titles are enforced by
 [.github/workflows/lint-pr-title.yml](.github/workflows/lint-pr-title.yml).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,47 @@ use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
+### Pull request titles
+
+PR titles must follow the [Conventional Commits](https://www.conventionalcommits.org/)
+format. PRs are squash-merged onto `main`, and the title becomes the squashed
+commit message — which Release-Please then parses to generate
+[CHANGELOG.md](CHANGELOG.md) and pick the next version. A malformed title means
+a missing or miscategorized changelog entry.
+
+**Format:** `<type>[optional scope]: <description>`
+
+Examples:
+- `feat(autoctx): add hill-climbing convergence check`
+- `fix(evaluate): handle missing scores.csv`
+- `feat!: drop legacy /autoctx:* slash commands`
+- `docs(skills): clarify bootstrap upload-URL step`
+
+#### Types
+
+| Type | Description | Version bump |
+| :--- | :--- | :--- |
+| **BREAKING CHANGE** | Anything with `!` after the type/scope (e.g. `feat!:` or `fix(api)!:`) introduces a breaking API change. | major |
+| **feat** | New user-visible feature. | minor |
+| **fix** | Bug fix. | patch |
+| **perf** | Performance improvement with no behavior change. | patch |
+| **docs** | Documentation only. | none |
+| **refactor** | Code change that is neither a feat nor a fix and does not change behavior. | none |
+| **test** | Adding or fixing tests. | none |
+| **build** | Build system, packaging, or dependency changes (used by Dependabot). | none |
+| **ci** | CI configuration files or scripts. | none |
+| **chore** | Anything else (internal cleanup, release commits). | none |
+| **revert** | Reverting a previous commit. | none |
+| **style** | Formatting and whitespace only (rare with auto-formatters). | none |
+
+Only `feat`, `fix`, `perf`, and breaking changes (`!`) appear in the user-facing
+changelog by default; other types are accepted but hidden. Use `chore` or
+`refactor` for internal-only PRs you do not want announced in release notes.
+
+Titles are enforced by
+[.github/workflows/lint-pr-title.yml](.github/workflows/lint-pr-title.yml).
+PRs with malformed titles fail the check and cannot merge.
+
 ## Further reading
 
 - [docs/development.md](docs/development.md) — local dev setup and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,15 @@ in their own top section regardless of the underlying type — even `chore!:` or
 `refactor!:` will be announced. Use `chore` or `refactor` (without `!`) for
 internal-only PRs you do not want surfaced in release notes.
 
+The visible-vs-hidden mapping comes from the
+[`conventional-changelog-conventionalcommits` preset][preset-defaults] that
+Release-Please loads when [release-please-config.json](release-please-config.json)
+does not override `changelog-sections`. Check that file for the authoritative
+list; to change which types are visible, override `changelog-sections` in
+[release-please-config.json](release-please-config.json).
+
+[preset-defaults]: https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/constants.js
+
 Titles are enforced by
 [.github/workflows/lint-pr-title.yml](.github/workflows/lint-pr-title.yml).
 PRs with malformed titles fail the check and cannot merge.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,26 +2,6 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
-  "changelog-sections": [
-    {
-      "type": "feat",
-      "section": "Features"
-    },
-    {
-      "type": "fix",
-      "section": "Bug Fixes"
-    },
-    {
-      "type": "chore",
-      "section": "Miscellaneous Chores",
-      "hidden": true
-    },
-    {
-      "type": "docs",
-      "section": "Documentation",
-      "hidden": true
-    }
-  ],
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary
- Drop the custom `changelog-sections` block in `release-please-config.json` so Release-Please falls back to its upstream default type set (no more silently-dropped `refactor:` / `ci:` / `build:` commits).
- Add `.github/workflows/lint-pr-title.yml` (`amannn/action-semantic-pull-request@v5`) to enforce Conventional Commits format on PR titles, which become the squash commit on `main`.
- Document the accepted types, SemVer impact, and default visible-vs-hidden behavior in `CONTRIBUTING.md`, with a link to the upstream preset as the source of truth.

## Why
PR titles are squash-merged onto `main` and parsed by Release-Please to generate the changelog and pick the next version. Without enforcement, malformed titles silently break the release pipeline — recent example: `cicd: fix toolbox command (#163)` was a typo of `ci:` and never appeared in `CHANGELOG.md`. This adds a CI gate plus the documentation to explain what's allowed and why.

> Note: this PR itself does not trigger the new lint — `pull_request_target` requires the workflow to exist on `main`.
