### PR TITLE
feat(mcp): add upload_context_set and download_context_set tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "google-genai==1.46.0",
     "toolbox-core==0.5.2",
     "google-cloud-geminidataanalytics==0.11.0",
+    "google-auth==2.41.1",
+    "requests==2.33.0",
 ]
 
 [project.scripts]

--- a/src/google/cloud/db_context_enrichment/common/context_store_client.py
+++ b/src/google/cloud/db_context_enrichment/common/context_store_client.py
@@ -1,0 +1,190 @@
+"""REST client for the Context Store API.
+
+Hand-rolled because the service is GOOGLE_INTERNAL and has no public SDK.
+All calls target the autopush sandbox endpoint pinned in this module.
+"""
+
+import json
+import time
+from typing import Any
+
+import google.auth
+import google.auth.exceptions
+import requests
+from google.auth.transport import requests as auth_requests
+
+from google.cloud.db_context_enrichment.model import context
+
+CONTEXT_STORE_ENDPOINT = "https://autopush-dataplex.sandbox.googleapis.com"
+CONTEXT_STORE_LOCATION = "us-central1"
+API_VERSION = "v1"
+DEFAULT_OAUTH_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
+
+# Per-request HTTP timeout + LRO poll schedule. Transient-error retry is
+# intentionally NOT done here — the MCP agent driving these tools retries
+# failed tool calls on its own, and the Cloud SDK (once available) will bring
+# proper retry back. Only the per-call timeout and op polling stay in this
+# hand-rolled client.
+_LRO_POLL_INTERVALS_SECONDS = (2.0, 4.0, 8.0, 16.0, 16.0, 16.0)
+_REQUEST_TIMEOUT_SECONDS = 30
+
+
+class ContextStoreClient:
+    """REST client for the Context Store API (autopush sandbox).
+
+    The client is stateless w.r.t. project. Operations that build a resource
+    path from IDs (`ensure_*`) take `project_id` as an explicit argument;
+    operations that take a fully-qualified resource name don't need it.
+
+    The quota project (billing / quota) is always taken from ADC's
+    `quota_project_id` and sent as `X-Goog-User-Project` on every request.
+    """
+
+    def __init__(self):
+        try:
+            credentials, _ = google.auth.default(scopes=DEFAULT_OAUTH_SCOPES)
+        except google.auth.exceptions.DefaultCredentialsError as e:
+            raise RuntimeError(
+                "No Application Default Credentials found. Run "
+                "'gcloud auth application-default login' first."
+            ) from e
+        if not credentials.quota_project_id:
+            raise RuntimeError(
+                "No quota project set. Run "
+                "'gcloud auth application-default set-quota-project <PROJECT_ID>'."
+            )
+        self._session = auth_requests.AuthorizedSession(credentials)
+        self._session.headers["X-Goog-User-Project"] = credentials.quota_project_id
+
+    def ensure_context_set_group(self, project_id: str, csg_id: str) -> str:
+        """Return a CSG's full resource name, creating it if absent.
+
+        Idempotent: a 409 (already exists, whether pre-existing or from a
+        concurrent create) is treated as success.
+        """
+        parent = f"projects/{project_id}/locations/{CONTEXT_STORE_LOCATION}"
+        create_url = (
+            f"{CONTEXT_STORE_ENDPOINT}/{API_VERSION}/{parent}/contextSetGroups"
+            f"?context_set_group_id={csg_id}"
+        )
+        try:
+            self._request_lro("POST", create_url, json_body={})
+        except requests.HTTPError as e:
+            if e.response.status_code != 409:
+                raise
+        return f"{parent}/contextSetGroups/{csg_id}"
+
+    def delete_context_set_group(self, csg_resource_name: str) -> None:
+        """Delete a ContextSetGroup by full resource name. Blocks on LRO.
+
+        Idempotent: a 404 (already deleted or never existed) is treated as
+        success. Cascades: all ContextSets inside the group are also deleted.
+        """
+        try:
+            self._request_lro(
+                "DELETE", f"{CONTEXT_STORE_ENDPOINT}/{API_VERSION}/{csg_resource_name}"
+            )
+        except requests.HTTPError as e:
+            if e.response.status_code != 404:
+                raise
+
+    def ensure_context_set(
+        self, project_id: str, csg_id: str, cs_id: str, version: str
+    ) -> str:
+        """Return a CS's full resource name, creating it (and the parent CSG)
+        if absent.
+
+        Idempotent: a 409 on the CS create is treated as success. Body is not
+        touched — the caller still needs `upload_context_set` to overwrite it.
+        """
+        csg_resource_name = self.ensure_context_set_group(project_id, csg_id)
+        url = (
+            f"{CONTEXT_STORE_ENDPOINT}/{API_VERSION}/{csg_resource_name}/contextSets"
+            f"?context_set_id={cs_id}"
+        )
+        body = {"context_set_id": cs_id, "version": version}
+        try:
+            self._request("POST", url, json_body=body)
+        except requests.HTTPError as e:
+            if e.response.status_code != 409:
+                raise
+        return f"{csg_resource_name}/contextSets/{cs_id}@{version}"
+
+    def upload_context_set(
+        self, cs_resource_name: str, ctx: context.ContextSet
+    ) -> None:
+        """Populate an existing ContextSet's body.
+
+        The resource must already exist (call `ensure_context_set` first).
+        """
+        url = f"{CONTEXT_STORE_ENDPOINT}/{API_VERSION}/{cs_resource_name}:upload"
+        body = {"context_json": ctx.model_dump_json(exclude_none=True)}
+        self._request("POST", url, json_body=body)
+
+    def download_context_set(self, cs_resource_name: str) -> context.ContextSet:
+        """Download and parse a ContextSet by full resource name."""
+        url = f"{CONTEXT_STORE_ENDPOINT}/{API_VERSION}/{cs_resource_name}:download"
+        resp = self._request("POST", url, json_body={})
+        raw = resp.get("contextJson")
+        if raw is None:
+            raise ValueError(f"DownloadContextSet response missing contextJson: {resp}")
+        # ContextSet models accept camelCase aliases too (see
+        # `_BaseContextModel`), so the server's mixed casing validates
+        # without conversion.
+        return context.ContextSet.model_validate(json.loads(raw))
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Send one HTTP request and return parsed JSON.
+
+        Returns an empty dict if the response body is empty (eg. 204 No
+        Content). Raises `requests.HTTPError` on 4xx/5xx,
+        `requests.RequestException` on network failure.
+        """
+        response = self._session.request(
+            method, url, json=json_body, timeout=_REQUEST_TIMEOUT_SECONDS
+        )
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    def _request_lro(
+        self,
+        method: str,
+        url: str,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue a request that returns an LRO and poll until it completes.
+
+        - HTTP layer (`_request`): each call returns 200; raises on 4xx/5xx.
+        - Op layer: `done` / `response` / `error` live in the JSON body, not
+          the HTTP status.
+        - Sleeps per `_LRO_POLL_INTERVALS_SECONDS`; raises `TimeoutError`
+          on budget exhaustion or `RuntimeError` on op-reported error.
+        """
+        op = self._request(method, url, json_body=json_body)
+        op_name = op.get("name")
+        if not op_name:
+            raise RuntimeError(f"{method} {url} returned no operation name: {op}")
+
+        # Skip the poll cycle if the initial op is already done (some LROs
+        # complete synchronously). Otherwise poll until it does or the
+        # budget is exhausted.
+        poll_url = f"{CONTEXT_STORE_ENDPOINT}/{API_VERSION}/{op_name}"
+        for delay in _LRO_POLL_INTERVALS_SECONDS:
+            if op.get("done"):
+                break
+            time.sleep(delay)
+            op = self._request("GET", poll_url)
+        if not op.get("done"):
+            raise TimeoutError(f"LRO {op_name} did not complete within the poll budget")
+        if "error" in op:
+            err = op["error"]
+            raise RuntimeError(
+                f"LRO {op_name} failed: [{err.get('code')}] "
+                f"{err.get('message', 'unknown LRO error')}"
+            )
+        return op.get("response", {})

--- a/src/google/cloud/db_context_enrichment/main.py
+++ b/src/google/cloud/db_context_enrichment/main.py
@@ -1,13 +1,18 @@
 import json
+import pathlib
 
 from fastmcp import FastMCP
 
-from google.cloud.db_context_enrichment.common import context_mutator
+from google.cloud.db_context_enrichment.common import (
+    context_mutator,
+    context_store_client,
+)
 from google.cloud.db_context_enrichment.dataset import dataset_generator
 from google.cloud.db_context_enrichment.evaluate import (
     evaluate_generator,
     result_reader,
 )
+from google.cloud.db_context_enrichment.model import context
 
 mcp = FastMCP("Context Engineering Agent MCP")
 
@@ -115,6 +120,72 @@ def generate_upload_url(
             return "Error: Missing instance_id, database_id, or project_id for spanner."
     else:
         return "Error: Invalid db_engine. Must be one of 'alloydb', 'cloudsql', or 'spanner'."
+
+
+# NOTE: `@mcp.tool` is intentionally NOT applied to upload_context_set /
+# download_context_set. The Context Store client library ships in this
+# release, but the MCP tool wrappers are held back until the Context Store
+# API is stable in production. Re-add the decorator to expose these to
+# agents when ready.
+def upload_context_set(
+    local_file_path: str,
+    project_id: str,
+    csg_id: str,
+    cs_id: str,
+    version: str,
+) -> str:
+    """
+    Upload a local ContextSet JSON file to the Context Store.
+
+    Resource hierarchy: a ContextSetGroup (CSG) is a logical container that
+    holds versioned ContextSets — typically one CSG per experiment, one
+    cs_id per lineage (eg. "autoctx"), and versions like "v0", "v1", "v2".
+
+    The CSG and the (cs_id, version) ContextSet resource are created if they
+    don't already exist; then the file contents are written as the
+    ContextSet body. Re-uploading the same (csg_id, cs_id, version)
+    overwrites the body.
+
+    Args:
+        local_file_path: Absolute path to a ContextSet JSON file.
+        project_id: GCP project where the CSG / CS should live. Typically
+            the same project the target DB lives in.
+        csg_id: ContextSetGroup ID (eg. an experiment name).
+        cs_id: ContextSet ID (eg. "autoctx"). Stable across versions.
+        version: Version label (eg. "baseline", "v1").
+
+    Returns:
+        Full ContextSet resource name, eg.
+        `projects/<p>/locations/<l>/contextSetGroups/<csg_id>/contextSets/<cs_id>@<version>`.
+    """
+    text = pathlib.Path(local_file_path).read_text()
+    ctx = context.ContextSet.model_validate_json(text)
+    client = context_store_client.ContextStoreClient()
+    cs_resource_name = client.ensure_context_set(project_id, csg_id, cs_id, version)
+    client.upload_context_set(cs_resource_name, ctx)
+    return cs_resource_name
+
+
+def download_context_set(cs_resource_name: str, output_file_path: str) -> str:
+    """
+    Download a ContextSet from the Context Store and write it to a local
+    JSON file. Parent directories are created as needed; the output file
+    is overwritten if it exists.
+
+    Args:
+        cs_resource_name: Full ContextSet resource name, eg.
+            `projects/<p>/locations/<l>/contextSetGroups/<csg_id>/contextSets/<cs_id>@<version>`.
+        output_file_path: Absolute path where the JSON file should be written.
+
+    Returns:
+        The output file path.
+    """
+    client = context_store_client.ContextStoreClient()
+    ctx = client.download_context_set(cs_resource_name)
+    out = pathlib.Path(output_file_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(ctx.model_dump_json(exclude_none=True, indent=2))
+    return output_file_path
 
 
 @mcp.tool

--- a/src/google/cloud/db_context_enrichment/model/context.py
+++ b/src/google/cloud/db_context_enrichment/model/context.py
@@ -1,7 +1,20 @@
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
 
 
-class ParameterizedTemplate(BaseModel):
+class _BaseContextModel(BaseModel):
+    """Shared base for all ContextSet models.
+
+    Accepts both snake_case field names and their camelCase aliases on
+    validation — needed because the Context Store API returns camelCase for
+    proto-known fields on download. Serialization stays snake_case by default
+    (Pydantic's `by_alias` defaults to False), so upload output is unchanged.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class ParameterizedTemplate(_BaseContextModel):
     """Defines the parameterized version of a SQL query and intent."""
 
     parameterized_sql: str = Field(
@@ -12,7 +25,7 @@ class ParameterizedTemplate(BaseModel):
     )
 
 
-class Template(BaseModel):
+class Template(_BaseContextModel):
     """Represents a single, complete template."""
 
     nl_query: str = Field(
@@ -26,15 +39,19 @@ class Template(BaseModel):
     parameterized: ParameterizedTemplate
 
 
-class ParameterizedFacet(BaseModel):
+class ParameterizedFacet(_BaseContextModel):
     """Defines the parameterized version of a SQL facet and intent."""
 
     parameterized_sql_snippet: str = Field(
         ...,
         description="The SQL facet with placeholders (eg., ).",
-        # "fragment" is deprecated, keep alias for backward compatibility
+        # "fragment" is deprecated, keep alias for backward compatibility.
+        # camelCase form is listed explicitly because validation_alias
+        # overrides the model-level alias_generator.
         validation_alias=AliasChoices(
-            "parameterized_sql_snippet", "parameterized_fragment"
+            "parameterized_sql_snippet",
+            "parameterizedSqlSnippet",
+            "parameterized_fragment",
         ),
     )
     parameterized_intent: str = Field(
@@ -42,14 +59,16 @@ class ParameterizedFacet(BaseModel):
     )
 
 
-class Facet(BaseModel):
+class Facet(_BaseContextModel):
     """Represents a single, complete facet."""
 
     sql_snippet: str = Field(
         ...,
         description="The corresponding, complete SQL facet.",
-        # "fragment" is deprecated, keep alias for backward compatibility
-        validation_alias=AliasChoices("sql_snippet", "fragment"),
+        # "fragment" is deprecated, keep alias for backward compatibility.
+        # camelCase form is listed explicitly because validation_alias
+        # overrides the model-level alias_generator.
+        validation_alias=AliasChoices("sql_snippet", "sqlSnippet", "fragment"),
     )
     intent: str = Field(..., description="The user's specific intent.")
     manifest: str = Field(
@@ -58,7 +77,7 @@ class Facet(BaseModel):
     parameterized: ParameterizedFacet
 
 
-class ValueSearch(BaseModel):
+class ValueSearch(_BaseContextModel):
     """Represents a single, complete value search."""
 
     query: str = Field(..., description="The parameterized SQL query (using $value).")
@@ -68,7 +87,7 @@ class ValueSearch(BaseModel):
     description: str | None = Field(None, description="Optional description.")
 
 
-class ContextSet(BaseModel):
+class ContextSet(_BaseContextModel):
     """A set of templates, facets and value searches."""
 
     templates: list[Template] | None = Field(
@@ -77,7 +96,8 @@ class ContextSet(BaseModel):
     facets: list[Facet] | None = Field(
         None,
         description="A list of SQL facets.",
-        # "fragments" is deprecated, keep alias for backward compatibility
+        # "fragments" is deprecated, keep alias for backward compatibility.
+        # No camelCase entry needed — to_camel("facets") == "facets".
         validation_alias=AliasChoices("facets", "fragments"),
     )
     value_searches: list[ValueSearch] | None = Field(

--- a/tests/google/cloud/db_context_enrichment/common/context_mutator_test.py
+++ b/tests/google/cloud/db_context_enrichment/common/context_mutator_test.py
@@ -1,5 +1,5 @@
 import json
-from pathlib import Path
+import pathlib
 
 import pytest
 
@@ -11,7 +11,7 @@ from google.cloud.db_context_enrichment.model.context import ContextSet
 
 
 # Helper to load existing JSON from disk to assert correctness
-def load_context_from_file(path: Path) -> dict:
+def load_context_from_file(path: pathlib.Path) -> dict:
     with open(path) as f:
         return json.load(f)
 
@@ -19,7 +19,7 @@ def load_context_from_file(path: Path) -> dict:
 # === TEST ADD / CREATE CASES ===
 
 
-def test_add_to_new_file(tmp_path: Path):
+def test_add_to_new_file(tmp_path: pathlib.Path):
     """Test creating a new context set file automatically when path doesn't exist."""
     file_path = tmp_path / "new_context.json"
 
@@ -51,7 +51,7 @@ def test_add_to_new_file(tmp_path: Path):
     )
 
 
-def test_add_to_existing_file(tmp_path: Path):
+def test_add_to_existing_file(tmp_path: pathlib.Path):
     """Test appending to an existing initialized context set file."""
     file_path = tmp_path / "exist_context.json"
 
@@ -95,7 +95,7 @@ def test_add_to_existing_file(tmp_path: Path):
 # === TEST DELETE CASES ===
 
 
-def test_delete_full_match(tmp_path: Path):
+def test_delete_full_match(tmp_path: pathlib.Path):
     """Test deleting an item using an exact matching identifier."""
     file_path = tmp_path / "delete_context.json"
 
@@ -121,7 +121,7 @@ def test_delete_full_match(tmp_path: Path):
     assert data["value_searches"][0]["query"] == "Q2"
 
 
-def test_delete_partial_match(tmp_path: Path):
+def test_delete_partial_match(tmp_path: pathlib.Path):
     """Test deleting an item using a subset partial match on the identifier."""
     file_path = tmp_path / "delete_context.json"
 
@@ -146,7 +146,7 @@ def test_delete_partial_match(tmp_path: Path):
     assert data["value_searches"][0]["query"] == "Q2"
 
 
-def test_delete_no_match(tmp_path: Path):
+def test_delete_no_match(tmp_path: pathlib.Path):
     """Test that a non-matching identifier leaves the list unchanged."""
     file_path = tmp_path / "delete_context.json"
     initial_context = {"value_searches": [{"query": "Q1", "concept_type": "City"}]}
@@ -167,7 +167,7 @@ def test_delete_no_match(tmp_path: Path):
 # === TEST UPDATE CASES ===
 
 
-def test_update_partial_match(tmp_path: Path):
+def test_update_partial_match(tmp_path: pathlib.Path):
     """Test updating an item when identifier acts as a partial match selector."""
     file_path = tmp_path / "update_context.json"
 
@@ -199,7 +199,7 @@ def test_update_partial_match(tmp_path: Path):
 # === TEST VALIDATION CASES ===
 
 
-def test_invalid_mutation_raises_validation_error(tmp_path: Path):
+def test_invalid_mutation_raises_validation_error(tmp_path: pathlib.Path):
     """Test that pushing an invalid payload for Add raises a ValueError immediately."""
     file_path = tmp_path / "valid_context.json"
 

--- a/tests/google/cloud/db_context_enrichment/common/context_store_client_test.py
+++ b/tests/google/cloud/db_context_enrichment/common/context_store_client_test.py
@@ -1,0 +1,445 @@
+import json
+from unittest.mock import MagicMock
+
+import google.auth.exceptions
+import pydantic
+import pytest
+import requests
+
+from google.cloud.db_context_enrichment.common import context_store_client
+from google.cloud.db_context_enrichment.common.context_store_client import (
+    ContextStoreClient,
+)
+from google.cloud.db_context_enrichment.model.context import ContextSet
+
+
+def _make_response(status_code: int, body=None):
+    """Build a fake requests.Response with controllable status/body.
+
+    For 4xx/5xx codes, `raise_for_status` is wired to raise
+    `requests.HTTPError`, matching real `requests` behavior.
+    """
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    if body is None:
+        response.content = b""
+        response.text = ""
+        response.json.side_effect = ValueError("no body")
+    elif isinstance(body, str):
+        response.content = body.encode()
+        response.text = body
+        response.json.side_effect = ValueError("not json")
+    else:
+        encoded = json.dumps(body)
+        response.content = encoded.encode()
+        response.text = encoded
+        response.json.return_value = body
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f"HTTP {status_code}", response=response
+        )
+    return response
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Construct a client with mocked ADC + a controllable session."""
+    fake_credentials = MagicMock()
+    fake_credentials.quota_project_id = "test-project"
+    fake_credentials.valid = True
+    fake_credentials.token = "fake-token"
+
+    monkeypatch.setattr(
+        "google.auth.default",
+        lambda scopes=None: (fake_credentials, None),
+    )
+    monkeypatch.setattr(
+        context_store_client.auth_requests,
+        "AuthorizedSession",
+        lambda creds: MagicMock(),
+    )
+    monkeypatch.setattr(context_store_client.time, "sleep", lambda *a, **k: None)
+
+    return ContextStoreClient()
+
+
+_CSG_RESOURCE_NAME = (
+    "projects/test-project/locations/us-central1/contextSetGroups/exp-1"
+)
+
+
+# === Constructor ===
+
+
+def test_constructor_raises_when_adc_missing(monkeypatch):
+    def raise_default(scopes=None):
+        raise google.auth.exceptions.DefaultCredentialsError("no ADC")
+
+    monkeypatch.setattr("google.auth.default", raise_default)
+
+    with pytest.raises(RuntimeError, match="Application Default Credentials"):
+        ContextStoreClient()
+
+
+def test_constructor_raises_when_no_quota_project(monkeypatch):
+    fake_credentials = MagicMock()
+    fake_credentials.quota_project_id = None
+    monkeypatch.setattr(
+        "google.auth.default",
+        lambda scopes=None: (fake_credentials, None),
+    )
+    monkeypatch.setattr(
+        context_store_client.auth_requests,
+        "AuthorizedSession",
+        lambda creds: MagicMock(),
+    )
+
+    with pytest.raises(RuntimeError, match="No quota project"):
+        ContextStoreClient()
+
+
+def test_constructor_sends_quota_project_header(monkeypatch):
+    fake_credentials = MagicMock()
+    fake_credentials.quota_project_id = "quota-proj"
+    monkeypatch.setattr(
+        "google.auth.default",
+        lambda scopes=None: (fake_credentials, None),
+    )
+    session_mock = MagicMock()
+    monkeypatch.setattr(
+        context_store_client.auth_requests,
+        "AuthorizedSession",
+        lambda creds: session_mock,
+    )
+    monkeypatch.setattr(context_store_client.time, "sleep", lambda *a, **k: None)
+
+    ContextStoreClient()
+
+    session_mock.headers.__setitem__.assert_any_call(
+        "X-Goog-User-Project", "quota-proj"
+    )
+
+
+def test_ensure_csg_uses_explicit_project_id(monkeypatch):
+    """The method-level `project_id` shapes the built resource path,
+    independent of the ADC quota project."""
+    fake_credentials = MagicMock()
+    fake_credentials.quota_project_id = "quota-proj"
+    monkeypatch.setattr(
+        "google.auth.default",
+        lambda scopes=None: (fake_credentials, None),
+    )
+    session_mock = MagicMock()
+    # ensure_csg's POST returns 409 (already exists) — treated as success.
+    session_mock.request.return_value = _make_response(
+        409, {"error": {"message": "exists"}}
+    )
+    monkeypatch.setattr(
+        context_store_client.auth_requests,
+        "AuthorizedSession",
+        lambda creds: session_mock,
+    )
+    monkeypatch.setattr(context_store_client.time, "sleep", lambda *a, **k: None)
+
+    client = ContextStoreClient()
+
+    # Header still comes from ADC quota project.
+    session_mock.headers.__setitem__.assert_any_call(
+        "X-Goog-User-Project", "quota-proj"
+    )
+    # Resource paths use the method-level project_id.
+    name = client.ensure_context_set_group("resource-proj", "g")
+    assert name == "projects/resource-proj/locations/us-central1/contextSetGroups/g"
+
+
+# === ensure_context_set_group ===
+
+
+def test_ensure_csg_creates_when_missing(client):
+    """Happy path: POST create returns an LRO op, we poll to done."""
+    client._session.request.side_effect = [
+        _make_response(200, {"name": "operations/op-123"}),
+        _make_response(200, {"done": True, "response": {}}),
+    ]
+
+    name = client.ensure_context_set_group("test-project", "exp-1")
+
+    assert name == _CSG_RESOURCE_NAME
+    assert client._session.request.call_count == 2
+
+
+def test_ensure_csg_lro_completes_synchronously(client):
+    """When the create response already has done: true, we skip polling."""
+    client._session.request.return_value = _make_response(
+        200, {"name": "operations/op", "done": True, "response": {}}
+    )
+
+    name = client.ensure_context_set_group("test-project", "exp-1")
+
+    assert name == _CSG_RESOURCE_NAME
+    # 1 request total: POST returns an already-done op. No poll GETs.
+    assert client._session.request.call_count == 1
+
+
+def test_ensure_csg_polls_until_done(client):
+    client._session.request.side_effect = [
+        _make_response(200, {"name": "operations/op-2"}),
+        _make_response(200, {"done": False}),
+        _make_response(200, {"done": False}),
+        _make_response(200, {"done": True, "response": {}}),
+    ]
+
+    name = client.ensure_context_set_group("test-project", "exp-1")
+
+    assert name == _CSG_RESOURCE_NAME
+    assert client._session.request.call_count == 4
+
+
+def test_ensure_csg_lro_error_raises(client):
+    client._session.request.side_effect = [
+        _make_response(200, {"name": "operations/op"}),
+        _make_response(200, {"done": True, "error": {"code": 5, "message": "boom"}}),
+    ]
+
+    with pytest.raises(RuntimeError, match="boom"):
+        client.ensure_context_set_group("test-project", "exp-1")
+
+
+def test_ensure_csg_lro_timeout(client):
+    polls = [_make_response(200, {"done": False})] * len(
+        context_store_client._LRO_POLL_INTERVALS_SECONDS
+    )
+    client._session.request.side_effect = [
+        _make_response(200, {"name": "operations/op"}),
+        *polls,
+    ]
+
+    with pytest.raises(TimeoutError, match="did not complete"):
+        client.ensure_context_set_group("test-project", "exp-1")
+
+
+def test_ensure_csg_treats_create_409_as_success(client):
+    """A 409 on create (already exists / race) is treated as success."""
+    client._session.request.return_value = _make_response(
+        409, {"error": {"message": "already exists"}}
+    )
+
+    name = client.ensure_context_set_group("test-project", "exp-1")
+
+    assert name == _CSG_RESOURCE_NAME
+    assert client._session.request.call_count == 1
+
+
+def test_ensure_csg_create_missing_operation_name_raises(client):
+    client._session.request.return_value = _make_response(
+        200, {}
+    )  # Create succeeded but no op name.
+
+    with pytest.raises(RuntimeError, match="no operation name"):
+        client.ensure_context_set_group("test-project", "exp-1")
+
+
+# === delete_context_set_group ===
+
+
+def test_delete_context_set_group_success(client):
+    client._session.request.side_effect = [
+        _make_response(200, {"name": "operations/op-del"}),
+        _make_response(200, {"done": True, "response": {}}),
+    ]
+
+    client.delete_context_set_group(_CSG_RESOURCE_NAME)
+
+    assert client._session.request.call_count == 2
+    first = client._session.request.call_args_list[0]
+    assert first.args[0] == "DELETE"
+
+
+def test_delete_context_set_group_missing_op_name_raises(client):
+    client._session.request.return_value = _make_response(200, {})
+
+    with pytest.raises(RuntimeError, match="no operation name"):
+        client.delete_context_set_group(_CSG_RESOURCE_NAME)
+
+
+def test_delete_context_set_group_treats_404_as_success(client):
+    """Deleting a CSG that doesn't exist is idempotent."""
+    client._session.request.return_value = _make_response(
+        404, {"error": {"message": "not found"}}
+    )
+
+    # Should not raise.
+    client.delete_context_set_group(_CSG_RESOURCE_NAME)
+
+
+# === ensure_context_set ===
+
+
+def test_ensure_cs_creates_when_missing(client):
+    # ensure_cs internally calls ensure_csg first: POST csg (409 = already
+    # exists), then POST cs (200 = created).
+    client._session.request.side_effect = [
+        _make_response(409, {"error": {"message": "csg exists"}}),  # ensure_csg
+        _make_response(200, {}),  # POST cs
+    ]
+
+    name = client.ensure_context_set(
+        "test-project", "exp-1", cs_id="autoctx", version="v1"
+    )
+
+    assert name == f"{_CSG_RESOURCE_NAME}/contextSets/autoctx@v1"
+    assert client._session.request.call_count == 2
+    # Last call is the CS POST.
+    call = client._session.request.call_args
+    assert call.args[0] == "POST"
+    sent_url = call.args[1] if len(call.args) > 1 else call.kwargs["url"]
+    assert sent_url.endswith(
+        "/contextSetGroups/exp-1/contextSets?context_set_id=autoctx"
+    )
+
+
+def test_ensure_cs_treats_409_as_success(client):
+    client._session.request.side_effect = [
+        _make_response(409, {"error": {"message": "csg exists"}}),  # ensure_csg
+        _make_response(409, {"error": {"message": "cs exists"}}),  # POST cs conflict
+    ]
+
+    name = client.ensure_context_set(
+        "test-project", "exp-1", cs_id="autoctx", version="v1"
+    )
+
+    # 409 on the CS create is swallowed; we return the resource name.
+    assert name == f"{_CSG_RESOURCE_NAME}/contextSets/autoctx@v1"
+
+
+def test_ensure_cs_reraises_non_409_errors(client):
+    client._session.request.side_effect = [
+        _make_response(409, {"error": {"message": "csg exists"}}),  # ensure_csg
+        _make_response(500, {"error": {"message": "boom"}}),  # POST cs errors
+    ]
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        client.ensure_context_set(
+            "test-project", "exp-1", cs_id="autoctx", version="v1"
+        )
+
+    assert excinfo.value.response.status_code == 500
+
+
+# === upload_context_set ===
+
+
+def test_upload_success(client):
+    client._session.request.return_value = _make_response(200, {})
+
+    resource = f"{_CSG_RESOURCE_NAME}/contextSets/autoctx@baseline"
+    client.upload_context_set(resource, ContextSet())
+
+    call = client._session.request.call_args
+    sent_url = call.args[1] if len(call.args) > 1 else call.kwargs["url"]
+    assert sent_url.endswith("/contextSets/autoctx@baseline:upload")
+    assert "context_json" in call.kwargs["json"]
+
+
+def test_upload_serializes_context_set_to_json_string(client):
+    client._session.request.return_value = _make_response(200, {})
+
+    resource = f"{_CSG_RESOURCE_NAME}/contextSets/autoctx@v1"
+    client.upload_context_set(resource, ContextSet())
+
+    body = client._session.request.call_args.kwargs["json"]
+    parsed = json.loads(body["context_json"])
+    assert isinstance(parsed, dict)
+
+
+# === download_context_set ===
+
+
+def test_download_success(client):
+    encoded = ContextSet().model_dump_json(exclude_none=True)
+    client._session.request.return_value = _make_response(200, {"contextJson": encoded})
+
+    result = client.download_context_set(f"{_CSG_RESOURCE_NAME}/contextSets/autoctx@v1")
+
+    assert isinstance(result, ContextSet)
+
+
+def test_download_missing_field_raises(client):
+    client._session.request.return_value = _make_response(200, {})
+
+    with pytest.raises(ValueError, match="missing contextJson"):
+        client.download_context_set(f"{_CSG_RESOURCE_NAME}/contextSets/autoctx@v1")
+
+
+def test_download_invalid_inner_json_raises(client):
+    client._session.request.return_value = _make_response(
+        200, {"contextJson": "not a json blob"}
+    )
+
+    # json.loads raises JSONDecodeError (a ValueError subclass).
+    with pytest.raises(ValueError):
+        client.download_context_set(f"{_CSG_RESOURCE_NAME}/contextSets/autoctx@v1")
+
+
+def test_download_invalid_context_set_shape_raises(client):
+    # contextJson is valid JSON but doesn't match ContextSet schema.
+    client._session.request.return_value = _make_response(
+        200, {"contextJson": '{"templates": "not-a-list"}'}
+    )
+
+    with pytest.raises(pydantic.ValidationError):
+        client.download_context_set(f"{_CSG_RESOURCE_NAME}/contextSets/autoctx@v1")
+
+
+# === HTTP error surfaces ===
+
+
+def test_authz_failures_surface_raw_403(client):
+    client._session.request.return_value = _make_response(
+        403, {"error": {"message": "denied"}}
+    )
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        client.ensure_context_set_group("test-project", "exp-1")
+
+    assert excinfo.value.response.status_code == 403
+    assert excinfo.value.response.json() == {"error": {"message": "denied"}}
+
+
+def test_non_retriable_4xx_raises_immediately(client):
+    client._session.request.return_value = _make_response(
+        400, {"error": {"message": "bad request"}}
+    )
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        client.ensure_context_set_group("test-project", "exp-1")
+
+    assert excinfo.value.response.status_code == 400
+    assert client._session.request.call_count == 1
+
+
+def test_error_exposes_raw_response_body(client):
+    """Callers can read structured server fields via `e.response.json()`."""
+    payload = {
+        "error": {
+            "code": 7,
+            "message": "permission denied",
+            "details": [{"@type": "type.googleapis.com/google.rpc.ErrorInfo"}],
+        }
+    }
+    client._session.request.return_value = _make_response(403, payload)
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        client.ensure_context_set_group("test-project", "exp-1")
+
+    assert excinfo.value.response.json() == payload
+
+
+def test_error_exposes_raw_text_when_body_not_json(client):
+    """When the body isn't JSON, `.response.text` still surfaces it."""
+    client._session.request.return_value = _make_response(400, "plain text crash")
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        client.ensure_context_set_group("test-project", "exp-1")
+
+    assert excinfo.value.response.text == "plain text crash"

--- a/tests/google/cloud/db_context_enrichment/main_test.py
+++ b/tests/google/cloud/db_context_enrichment/main_test.py
@@ -1,10 +1,10 @@
 import json
-from pathlib import Path
+import pathlib
 
 from google.cloud.db_context_enrichment.main import mutate_context_set
 
 
-def test_mutate_context_set_success(tmp_path: Path):
+def test_mutate_context_set_success(tmp_path: pathlib.Path):
     file_path = tmp_path / "context.json"
     mutations = [
         {
@@ -33,14 +33,14 @@ def test_mutate_context_set_success(tmp_path: Path):
     assert data["templates"][0]["nl_query"] == "Test query"
 
 
-def test_mutate_context_set_invalid_json(tmp_path: Path):
+def test_mutate_context_set_invalid_json(tmp_path: pathlib.Path):
     file_path = tmp_path / "context.json"
     result = mutate_context_set(str(file_path), "invalid json")
     assert "Error applying mutations" in result
     assert "JSONDecodeError" in result or "invalid json" in result or "Error" in result
 
 
-def test_mutate_context_set_non_list_json(tmp_path: Path):
+def test_mutate_context_set_non_list_json(tmp_path: pathlib.Path):
     file_path = tmp_path / "context.json"
     result = mutate_context_set(
         str(file_path), json.dumps({"operation": "add", "type": "template"})
@@ -48,7 +48,7 @@ def test_mutate_context_set_non_list_json(tmp_path: Path):
     assert "must be a JSON list" in result
 
 
-def test_mutate_context_set_validation_error(tmp_path: Path):
+def test_mutate_context_set_validation_error(tmp_path: pathlib.Path):
     file_path = tmp_path / "context.json"
     # Invalid operation
     mutations = [{"operation": "invalid", "type": "template"}]

--- a/uv.lock
+++ b/uv.lock
@@ -728,8 +728,10 @@ version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "google-auth" },
     { name = "google-cloud-geminidataanalytics" },
     { name = "google-genai" },
+    { name = "requests" },
     { name = "toolbox-core" },
 ]
 
@@ -749,10 +751,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = "==3.3.1" },
+    { name = "google-auth", specifier = "==2.41.1" },
     { name = "google-cloud-geminidataanalytics", specifier = "==0.11.0" },
     { name = "google-genai", specifier = "==1.46.0" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-asyncio", marker = "extra == 'test'" },
+    { name = "requests", specifier = "==2.33.0" },
     { name = "toolbox-core", specifier = "==0.5.2" },
 ]
 provides-extras = ["test"]


### PR DESCRIPTION
## Summary
- Adds two MCP tools — `upload_context_set` and `download_context_set` — for programmatic Context Store access, removing the manual "upload via GCP Database Studio" step from evaluation / hillclimb workflows.
- New hand-rolled REST client (`common/context_store_client.py`) since the Context Store API has no public SDK yet — marked in comments as a stopgap to be replaced when the SDK ships.
- Enables Pydantic camelCase aliases on ContextSet models so downloaded bodies validate without conversion.
