### PR TITLE
refactor(mcp): rename generate_evalbench_configs param experiment_name to output_dir

### DIFF
--- a/plugin/skills/context-engineering-workflow/references/evaluate/evaluate.md
+++ b/plugin/skills/context-engineering-workflow/references/evaluate/evaluate.md
@@ -61,7 +61,7 @@ Follow these steps exactly in order:
 3. **Config Generation (Core Execution):**
    - Use the `generate_evalbench_configs` MCP tool. This is the **only** way to generate Evalbench configs. Never invent configs from scratch.
    - If the tool fails, analyze the error and retry with corrected inputs. If it is an internal system error, STOP and inform the user.
-   - Provide the selected `experiment_name`, `dataset_path`, `context_set_id`, absolute `toolbox_config_path` (e.g. `autoctx/tools.yaml`), and selected `toolbox_source_name`.
+   - Provide the selected `output_dir` (must be `autoctx/experiments/<experiment_name>/`), `dataset_path`, `context_set_id`, absolute `toolbox_config_path` (e.g. `autoctx/tools.yaml`), and selected `toolbox_source_name`.
    - The tool will automatically write all generated configuration files (including `golden_queries.json`) directly to the `eval_configs/` directory inside the chosen `autoctx/experiments/<experiment_name>/` folder.
    - You do not need to manually write or extract file contents. Verify that the files have materialized if needed.
 

--- a/src/google/cloud/db_context_enrichment/evaluate/evaluate_generator.py
+++ b/src/google/cloud/db_context_enrichment/evaluate/evaluate_generator.py
@@ -23,7 +23,7 @@ GOLDEN_QUERIES_NAME = "golden_queries.json"
 
 
 def generate_evalbench_configs(
-    experiment_name: str,
+    output_dir: str,
     dataset_path: str,
     context_set_id: str,
     toolbox_config_path: str,
@@ -32,6 +32,10 @@ def generate_evalbench_configs(
     """
     Main entrypoint: Generates Evalbench-compatible YAML configurations natively using
     private DB format converters and the google-cloud-geminidataanalytics API validations.
+
+    All output files land under `<output_dir>/eval_configs/`. The generated
+    `run_config.yaml` also points evalbench at `<output_dir>/eval_reports/`
+    for its results.
     """
     params = _extract_toolbox_params(toolbox_config_path, toolbox_source_name)
     generator = _get_db_generator(params)
@@ -39,13 +43,13 @@ def generate_evalbench_configs(
     db_config_yaml = generator.generate_db_config()
     model_config_yaml = generator.generate_model_config(context_set_id)
     llmrater_config_yaml = _generate_llmrater_config(params.get("project"))
-    run_config_yaml = _generate_run_config(experiment_name, generator.DIALECT)
+    run_config_yaml = _generate_run_config(output_dir, generator.DIALECT)
 
     # Convert simplified dataset to EvalBench standard format
     golden_queries_json = _convert_dataset(dataset_path, generator.DIALECT)
 
     # Write all files directly
-    eval_configs_dir = f"autoctx/experiments/{experiment_name}/eval_configs"
+    eval_configs_dir = os.path.join(output_dir, "eval_configs")
     os.makedirs(eval_configs_dir, exist_ok=True)
 
     with open(os.path.join(eval_configs_dir, DB_CONFIG_NAME), "w") as f:
@@ -140,10 +144,17 @@ def _get_db_generator(params: dict[str, Any]) -> BaseDBConfigGenerator:
     return generators[source_type](params)
 
 
-def _generate_run_config(experiment_name: str, dialect: str) -> str:
-    """Generates the main EvalBench Run Experiment scaffolding."""
-    configs_dir = f"autoctx/experiments/{experiment_name}/eval_configs"
-    reports_dir = f"autoctx/experiments/{experiment_name}/eval_reports"
+def _generate_run_config(output_dir: str, dialect: str) -> str:
+    """Generates the main EvalBench Run Experiment scaffolding.
+
+    Path values embedded in the YAML are normalized to POSIX separators so
+    the generated file is consistent across platforms (avoids mixed
+    `C:\\out\\eval_configs/db_config.yaml` on Windows and keeps string
+    assertions in tests portable).
+    """
+    output_dir_posix = output_dir.replace(os.sep, "/")
+    configs_dir = f"{output_dir_posix}/eval_configs"
+    reports_dir = f"{output_dir_posix}/eval_reports"
 
     return textwrap.dedent(f"""\
         ############################################################

--- a/src/google/cloud/db_context_enrichment/main.py
+++ b/src/google/cloud/db_context_enrichment/main.py
@@ -41,7 +41,7 @@ async def generate_dataset(
 
 @mcp.tool
 def generate_evalbench_configs(
-    experiment_name: str,
+    output_dir: str,
     dataset_path: str,
     context_set_id: str,
     toolbox_config_path: str,
@@ -50,17 +50,20 @@ def generate_evalbench_configs(
     """
     Generates Evalbench YAML configurations and converts the user-facing golden dataset to be compatible for evaluation, saving all files directly to disk.
 
-    This tool writes the following files inside `experiments/<experiment_name>/eval_configs/`:
+    This tool writes the following files inside `<output_dir>/eval_configs/`:
     - `db_config.yaml`
     - `model_config.yaml`
     - `run_config.yaml`
     - `llmrater_config.yaml`
     - `golden_queries.json` (converted to EvalBench internal format)
 
+    The generated `run_config.yaml` also points evalbench at
+    `<output_dir>/eval_reports/` for its results.
+
     Args:
-        experiment_name: The name of the target experiment folder.
+        output_dir: Directory (absolute or workspace-relative) where the eval configs and reports should live. Created if missing.
         dataset_path: The absolute path to the golden dataset file in the simplified user-facing format (JSON list of objects with keys: "id", "database", "nlq", "golden_sql").
-        context_set_id: The specific context_set_id inside the experiment.
+        context_set_id: Full ContextSet resource name to evaluate against.
         toolbox_config_path: The absolute path to the tools.yaml configuration file.
         toolbox_source_name: The name of the database source to use inside tools.yaml. The underlying source block must use a supported 'type' (cloud-sql-postgres, cloud-sql-mysql, spanner, alloydb-postgres).
 
@@ -68,13 +71,13 @@ def generate_evalbench_configs(
         A message indicating that the configuration files were successfully created.
     """
     evaluate_generator.generate_evalbench_configs(
-        experiment_name,
+        output_dir,
         dataset_path,
         context_set_id,
         toolbox_config_path,
         toolbox_source_name,
     )
-    return f"Successfully generated all configs for evaluation in experiments/{experiment_name}/eval_configs/"
+    return f"Successfully generated all configs for evaluation in {output_dir}/eval_configs/"
 
 
 @mcp.tool

--- a/tests/google/cloud/db_context_enrichment/evaluate/evaluate_generator_test.py
+++ b/tests/google/cloud/db_context_enrichment/evaluate/evaluate_generator_test.py
@@ -1,4 +1,5 @@
 import json
+import os
 import textwrap
 from unittest.mock import mock_open, patch
 
@@ -117,7 +118,7 @@ def test_generate_evalbench_configs():
                 "google.cloud.db_context_enrichment.evaluate.evaluate_generator.os.makedirs"
             ) as mock_makedirs:
                 configs = generate_evalbench_configs(
-                    experiment_name="test-exp",
+                    output_dir="/test/out",
                     dataset_path="/local/path/data.json",
                     context_set_id="context-123",
                     toolbox_config_path="/fake/tools.yaml",
@@ -125,22 +126,17 @@ def test_generate_evalbench_configs():
                 )
 
     assert configs is None
-    mock_makedirs.assert_called_once_with(
-        "autoctx/experiments/test-exp/eval_configs", exist_ok=True
-    )
+    # Filesystem operations use native separators (backslash on Windows) —
+    # match with os.path.join so assertions are platform-portable.
+    eval_configs_dir = os.path.join("/test/out", "eval_configs")
+    mock_makedirs.assert_called_once_with(eval_configs_dir, exist_ok=True)
 
     # Verify all file writes
-    m.assert_any_call("autoctx/experiments/test-exp/eval_configs/db_config.yaml", "w")
-    m.assert_any_call(
-        "autoctx/experiments/test-exp/eval_configs/model_config.yaml", "w"
-    )
-    m.assert_any_call("autoctx/experiments/test-exp/eval_configs/run_config.yaml", "w")
-    m.assert_any_call(
-        "autoctx/experiments/test-exp/eval_configs/llmrater_config.yaml", "w"
-    )
-    m.assert_any_call(
-        "autoctx/experiments/test-exp/eval_configs/golden_queries.json", "w"
-    )
+    m.assert_any_call(os.path.join(eval_configs_dir, "db_config.yaml"), "w")
+    m.assert_any_call(os.path.join(eval_configs_dir, "model_config.yaml"), "w")
+    m.assert_any_call(os.path.join(eval_configs_dir, "run_config.yaml"), "w")
+    m.assert_any_call(os.path.join(eval_configs_dir, "llmrater_config.yaml"), "w")
+    m.assert_any_call(os.path.join(eval_configs_dir, "golden_queries.json"), "w")
 
     expected_db_config = textwrap.dedent("""\
         db_type: postgres
@@ -182,10 +178,10 @@ def test_generate_evalbench_configs():
         ############################################################
         ### Dataset / Eval Items
         ############################################################
-        dataset_config: autoctx/experiments/test-exp/eval_configs/golden_queries.json
+        dataset_config: /test/out/eval_configs/golden_queries.json
         dataset_format: evalbench-standard-format
         database_configs:
-         - autoctx/experiments/test-exp/eval_configs/db_config.yaml
+         - /test/out/eval_configs/db_config.yaml
         dialect: postgres    # DB connection mapping
         query_types:
          - dql
@@ -193,7 +189,7 @@ def test_generate_evalbench_configs():
         ############################################################
         ### Prompt and Generation Modules
         ############################################################
-        model_config: autoctx/experiments/test-exp/eval_configs/model_config.yaml
+        model_config: /test/out/eval_configs/model_config.yaml
         prompt_generator: 'NOOPGenerator'
 
         ############################################################
@@ -208,14 +204,14 @@ def test_generate_evalbench_configs():
         ############################################################
         scorers:
           llmrater:
-            model_config: autoctx/experiments/test-exp/eval_configs/llmrater_config.yaml
+            model_config: /test/out/eval_configs/llmrater_config.yaml
 
         ############################################################
         ### Reporting Related Configs
         ############################################################
         reporting:
           csv:
-            output_directory: 'autoctx/experiments/test-exp/eval_reports/'
+            output_directory: '/test/out/eval_reports/'
     """).strip()
 
     # Verify content written
@@ -249,7 +245,7 @@ def test_generate_evalbench_configs_env_interpolation():
                     "google.cloud.db_context_enrichment.evaluate.evaluate_generator.os.makedirs"
                 ):
                     configs = generate_evalbench_configs(
-                        experiment_name="test-exp",
+                        output_dir="/test/out",
                         dataset_path="/local/path/data.json",
                         context_set_id="context-123",
                         toolbox_config_path="/fake/tools.yaml",
@@ -285,7 +281,7 @@ def test_generate_evalbench_configs_env_fallback():
                     "google.cloud.db_context_enrichment.evaluate.evaluate_generator.os.makedirs"
                 ):
                     configs = generate_evalbench_configs(
-                        experiment_name="test-exp",
+                        output_dir="/test/out",
                         dataset_path="/local/path/data.json",
                         context_set_id="context-123",
                         toolbox_config_path="/fake/tools.yaml",


### PR DESCRIPTION
## Summary
- Renames `generate_evalbench_configs`'s `experiment_name` param to `output_dir` and drops the hardcoded `autoctx/experiments/<name>/` prefix — the tool now writes to whatever path the caller passes.
- Decouples the tool from the workspace convention; agents still pass `autoctx/experiments/<experiment_name>/` per the current skill flow, but callers with different layouts (auto-hillclimb, cross-project) aren't forced into it.
- Updates `evaluate.md` to reflect the renamed param.
