### PR TITLE
fix: Improve to instruction to revert back the prompt to the original CUJ prompt

### DIFF
--- a/evals/eval-dataset-gen/dataset.json
+++ b/evals/eval-dataset-gen/dataset.json
@@ -2,7 +2,7 @@
   "scenarios": [
     {
       "id": "autoctx:generate-dataset-resolve-biz-rule-shift",
-      "starting_prompt": "Use context engineering, generate an evaluation dataset of SQL/Question pairs for petstore application named golden.json",
+      "starting_prompt": "Generate an evaluation dataset of SQL/Question pairs for petstore application named golden.json",
       "conversation_plan": "Ask the agent to generate a evaluation dataset of SQL/Question pairs in postgres dialect for the petstore application whose design doc and source codes can be found in the directory `./app_data`, save the generated pairs in output file named golden.json. You should terminate the conversation immediately after the agent successfully generated the dataset, even if the agent prompts you to perform evaluation or take next steps. At the end of the conversation.",
       "expected_trajectory": [],
       "kind": "agents",
@@ -18,7 +18,7 @@
     },
     {
       "id": "autoctx:generate-dataset-resolve-cryptic-schema",
-      "starting_prompt": "Use context engineering, generate an evaluation dataset of SQL/Question pairs for ecommerce application named golden.json",
+      "starting_prompt": "Generate an evaluation dataset of SQL/Question pairs for ecommerce application named golden.json",
       "conversation_plan": "Ask the agent to generate a evaluation dataset of SQL/Question pairs in postgres dialect for the ecommerce application whose business context doc can be found in the directory `./app_data`, save the generated pairs in output file named golden.json. You should terminate the conversation immediately after the agent successfully generated the dataset, even if the agent prompts you to perform evaluation or take next steps. At the end of the conversation.",
       "expected_trajectory": [],
       "kind": "agents",
@@ -34,7 +34,7 @@
     },
     {
       "id": "autoctx:generate-dataset-grounding-local-code",
-      "starting_prompt": "Use context engineering, generate an evaluation dataset of SQL/Question pairs for hr application named golden.json",
+      "starting_prompt": "Generate an evaluation dataset of SQL/Question pairs for hr application named golden.json",
       "conversation_plan": "Ask the agent to generate a evaluation dataset of SQL/Question pairs in postgres dialect for the hr application whose source codes can be found in the directory `./app_data`, save the generated pairs in output file named golden.json. You should terminate the conversation immediately after the agent successfully generated the dataset, even if the agent prompts you to perform evaluation or take next steps. At the end of the conversation.",
       "expected_trajectory": [],
       "kind": "agents",
@@ -50,7 +50,7 @@
     },
     {
       "id": "autoctx:generate-dataset-grounding-github-code",
-      "starting_prompt": "Use context engineering, generate an evaluation dataset of SQL/Question pairs for property search application named golden.json",
+      "starting_prompt": "Generate an evaluation dataset of SQL/Question pairs for property search application named golden.json",
       "conversation_plan": "Ask the agent (trigger `context-engineering-workflow` skill) to generate a evaluation dataset of SQL/Question pairs in postgres dialect for the application at https://github.com/kupp0/google-dach-summit26-database-labs/tree/main/labs/03_fullstack_ai_app_property_search, save the generated pairs in output file named golden.json. You should terminate the conversation immediately after the agent successfully generated the dataset, even if the agent prompts you to perform evaluation or take next steps. At the end of the conversation.",
       "expected_trajectory": [],
       "kind": "agents",
@@ -66,7 +66,7 @@
     },
     {
       "id": "autoctx:generate-dataset-grounding-querylog",
-      "starting_prompt": "Use context engineering, generate an evaluation dataset consisting of SQL/Question pairs for my alloydb database financial named golden.json",
+      "starting_prompt": "Generate an evaluation dataset consisting of SQL/Question pairs for my alloydb database financial named golden.json",
       "conversation_plan": "Ask the agent to generate a evaluation dataset consisting of 5 SQL/Question pairs in postgres dialect for my alloydb database financial whose query log can be found in the file `./app_data/querylog.txt`, save the generated pairs in output file named golden.json. You should terminate the conversation immediately after the agent successfully generated the dataset, even if the agent prompts you to perform evaluation or take next steps. At the end of the conversation.",
       "expected_trajectory": [],
       "kind": "agents",

--- a/src/google/cloud/db_context_enrichment/main.py
+++ b/src/google/cloud/db_context_enrichment/main.py
@@ -21,8 +21,8 @@ async def generate_dataset(
     Validates a list of evaluation dataset entries and saves them to a JSON file. This tool is called when the agent trigger the `context-engineering-workflow` skill to generate a dataset for evaluation.
 
     Only call this tool as part of .../context-engineering-workflow/SKILL.md 's workflow.
-    If this tool is ever to be called, the agent must also invoke context engineering, and make sure that the `context-engineering-workflow` skill is triggered and 
-    the `<skill-dir>/references/dataset_generation/dataset_generation.md` is read to provide guidance on how to author well-formed 
+    If this tool is ever to be called, the agent must also invoke context engineering, and make sure that the `context-engineering-workflow` skill is triggered and
+    the `<skill-dir>/references/dataset_generation/dataset_generation.md` is read to provide guidance on how to author well-formed
     dataset entries that are provided as input to this tool.
 
     Args:

--- a/src/google/cloud/db_context_enrichment/main.py
+++ b/src/google/cloud/db_context_enrichment/main.py
@@ -20,7 +20,10 @@ async def generate_dataset(
     """
     Validates a list of evaluation dataset entries and saves them to a JSON file. This tool is called when the agent trigger the `context-engineering-workflow` skill to generate a dataset for evaluation.
 
-    If this tool is ever called, the agent must also make sure that the `context-engineering-workflow` skill is triggered and the `<skill-dir>/references/dataset_generation/dataset_generation.md` is read to provide guidance on how to author well-formed dataset entries.
+    Only call this tool as part of .../context-engineering-workflow/SKILL.md 's workflow.
+    If this tool is ever to be called, the agent must also invoke context engineering, and make sure that the `context-engineering-workflow` skill is triggered and 
+    the `<skill-dir>/references/dataset_generation/dataset_generation.md` is read to provide guidance on how to author well-formed 
+    dataset entries that are provided as input to this tool.
 
     Args:
         dataset_entries_json: A JSON string representing a list of dataset items.

--- a/src/google/cloud/db_context_enrichment/main.py
+++ b/src/google/cloud/db_context_enrichment/main.py
@@ -18,12 +18,15 @@ async def generate_dataset(
     output_file_path: str,
 ) -> str:
     """
-    Validates a list of evaluation dataset entries and saves them to a JSON file. This tool is called when the agent trigger the `context-engineering-workflow` skill to generate a dataset for evaluation.
+    Validates a list of evaluation dataset entries and saves them to a JSON file. This is the REQUIRED tool for generating 'golden' datasets.
 
-    Only call this tool as part of .../context-engineering-workflow/SKILL.md 's workflow.
-    If this tool is ever to be called, the agent must also invoke context engineering, and make sure that the `context-engineering-workflow` skill is triggered and
-    the `<skill-dir>/references/dataset_generation/dataset_generation.md` is read to provide guidance on how to author well-formed
-    dataset entries that are provided as input to this tool.
+    CRITICAL: Any request to generate an evaluation dataset MUST follow the "context-engineering-workflow" skill.
+    Do NOT use generic file-writing tools to save the golden dataset. Using this tool is the final step of the dataset generation workflow.
+
+    The workflow REQUIRES the following steps BEFORE calling this tool:
+    1. Activate the `context-engineering-workflow` skill.
+    2. Read `<skill-dir>/references/dataset_generation/dataset_generation.md` for the full procedure.
+    3. Generate mandatory audit reports (evalset_environment_inputs.md, evalset_gen_plan.md, evalset_report_pair_level.md, evalset_report_dataset_level.md) as specified in the workflow. These files are required for the verification process to pass.
 
     Args:
         dataset_entries_json: A JSON string representing a list of dataset items.


### PR DESCRIPTION
Improve the instruction (e.g. MCP tool description) so that the prompt can be reverted back to the original CUJs prompt without the keyword such as "Use context engineering".