### PR TITLE
feat(plugin): support agent plugin spec

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -30,6 +30,17 @@ jobs:
             echo "::error file=$FILE::version pin mismatch: \$.version=$VERSION but args[0]=$ARG (expected $EXPECTED)"
             exit 1
           fi
+      - name: Check mcp.json version matches uvx args pin
+        run: |
+          set -euo pipefail
+          FILE=plugin/mcp.json
+          VERSION=$(jq -r '.version' plugin/plugin.json)
+          ARG=$(jq -r '.mcpServers["db-context-engineering"].args[0]' "$FILE")
+          EXPECTED="google-cloud-db-context-engineering@${VERSION}"
+          if [ "$ARG" != "$EXPECTED" ]; then
+            echo "::error file=$FILE::version pin mismatch: plugin/plugin.json \$.version=$VERSION but args[0]=$ARG (expected $EXPECTED)"
+            exit 1
+          fi
       - name: Check plugin.json toolbox pin matches pyproject toolbox_version
         run: |
           set -euo pipefail
@@ -67,6 +78,17 @@ jobs:
         run: |
           set -euo pipefail
           FILE=dev-plugin/gemini-extension.json
+          TOOLBOX_VERSION=$(grep -o '^toolbox_version = "[^"]*"' pyproject.toml | cut -d '"' -f 2)
+          ARG=$(jq -r '.mcpServers["toolbox"].args[0]' "$FILE")
+          EXPECTED="toolbox-server@${TOOLBOX_VERSION}"
+          if [ "$ARG" != "$EXPECTED" ]; then
+            echo "::error file=$FILE::toolbox pin mismatch: pyproject toolbox_version=$TOOLBOX_VERSION but args[0]=$ARG (expected $EXPECTED)"
+            exit 1
+          fi
+      - name: Check mcp.json toolbox pin matches pyproject toolbox_version
+        run: |
+          set -euo pipefail
+          FILE=plugin/mcp.json
           TOOLBOX_VERSION=$(grep -o '^toolbox_version = "[^"]*"' pyproject.toml | cut -d '"' -f 2)
           ARG=$(jq -r '.mcpServers["toolbox"].args[0]' "$FILE")
           EXPECTED="toolbox-server@${TOOLBOX_VERSION}"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -3,6 +3,9 @@ name: Presubmit
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate-mcp-version-pin:
     runs-on: ubuntu-latest

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -7,7 +7,7 @@ jobs:
   validate-mcp-version-pin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Check plugin.json version matches uvx args pin
         run: |
           set -euo pipefail
@@ -130,7 +130,7 @@ jobs:
   lint-and-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install Ruff
         run: pipx install ruff
       - name: Lint with Ruff
@@ -141,9 +141,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -151,7 +151,7 @@ jobs:
         run: pipx install uv
 
       - name: Cache uv dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/sync-mcp-version.yml
+++ b/.github/workflows/sync-mcp-version.yml
@@ -26,7 +26,7 @@ jobs:
     if: startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -54,14 +54,17 @@ jobs:
           mv plugin/mcp.json.tmp plugin/mcp.json
 
       - name: Commit if changed
+        env:
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
         run: |
           FILES="plugin/.claude-plugin/plugin.json gemini-extension.json plugin/mcp.json"
           if git diff --quiet -- $FILES; then
             echo "args[0] already in sync; nothing to do."
             exit 0
           fi
-          git config user.name "${{ github.event.pull_request.user.login }}"
-          git config user.email "${{ github.event.pull_request.user.id }}+${{ github.event.pull_request.user.login }}@users.noreply.github.com"
+          git config user.name "$PR_AUTHOR_LOGIN"
+          git config user.email "${PR_AUTHOR_ID}+${PR_AUTHOR_LOGIN}@users.noreply.github.com"
           git add $FILES
           git commit -m "chore: sync MCP server version pin in plugin manifests"
           git push

--- a/.github/workflows/sync-mcp-version.yml
+++ b/.github/workflows/sync-mcp-version.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - "plugin/.claude-plugin/plugin.json"
       - "gemini-extension.json"
+      - "plugin/plugin.json"
+      - "plugin/mcp.json"
 
 permissions:
   contents: write
@@ -32,6 +34,7 @@ jobs:
       - name: Rewrite args[0] to match each manifest's version
         run: |
           set -euo pipefail
+          # Manifests that carry their own $.version.
           for FILE in plugin/.claude-plugin/plugin.json gemini-extension.json; do
             VERSION=$(jq -r '.version' "$FILE")
             PIN="google-cloud-db-context-engineering@${VERSION}"
@@ -40,15 +43,25 @@ jobs:
               "$FILE" > "$FILE.tmp"
             mv "$FILE.tmp" "$FILE"
           done
+          # The Agent Plugins mcp.json has no $.version of its own; source it
+          # from the sibling plugin.json (bumped by release-please) so the pin
+          # stays atomic with the released payload.
+          MCP_VERSION=$(jq -r '.version' plugin/plugin.json)
+          PIN="google-cloud-db-context-engineering@${MCP_VERSION}"
+          jq --arg pin "$PIN" \
+            '.mcpServers["db-context-engineering"].args[0] = $pin' \
+            plugin/mcp.json > plugin/mcp.json.tmp
+          mv plugin/mcp.json.tmp plugin/mcp.json
 
       - name: Commit if changed
         run: |
-          if git diff --quiet plugin/.claude-plugin/plugin.json gemini-extension.json; then
+          FILES="plugin/.claude-plugin/plugin.json gemini-extension.json plugin/mcp.json"
+          if git diff --quiet -- $FILES; then
             echo "args[0] already in sync; nothing to do."
             exit 0
           fi
           git config user.name "${{ github.event.pull_request.user.login }}"
           git config user.email "${{ github.event.pull_request.user.id }}+${{ github.event.pull_request.user.login }}@users.noreply.github.com"
-          git add plugin/.claude-plugin/plugin.json gemini-extension.json
+          git add $FILES
           git commit -m "chore: sync MCP server version pin in plugin manifests"
           git push

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ You can provide business artifacts directly to the agent from local filesystems 
 
 ---
 
+## Installing via a compatible Agent Plugins client
+
+This repository ships a valid [Agent Plugins](https://github.com/agentplugins/agent-plugins-spec) (v1) plugin under [`plugin/`](plugin/), bundling both agent skills and its MCP servers. Any [Agent Plugins–compatible client](https://agent-plugins.org/compatible-clients) (VS Code, Cursor, GitHub Copilot, Kiro, and others) can install it directly using its own built-in plugin command — no extra tooling required — by pointing at this repository:
+
+```
+https://github.com/GoogleCloudPlatform/db-context-enrichment
+```
+
+See your agent's documentation for its exact install command.
+
+---
+
 ## How to Use
 
 Launch your agent harness (Gemini CLI, Claude Code, or Antigravity) in your workspace directory and interact in natural language:

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "db-context-engineering": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "google-cloud-db-context-engineering@0.7.0"
+      ]
+    },
+    "toolbox": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "toolbox-server@1.4.0",
+        "--config",
+        "autoctx/tools.yaml",
+        "--stdio"
+      ]
+    }
+  }
+}

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "db-context-engineering",
+  "version": "0.7.0",
+  "description": "Context Engineering Agent for generating natural language to SQL templates, facets, and value searches.",
+  "author": {
+    "name": "Google Cloud Platform"
+  },
+  "repository": "https://github.com/GoogleCloudPlatform/db-context-enrichment",
+  "license": "Apache-2.0",
+  "keywords": [
+    "database",
+    "context-engineering",
+    "nl2sql",
+    "google-cloud",
+    "mcp"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,6 +24,11 @@
         },
         {
           "type": "json",
+          "path": "plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "gemini-extension.json",
           "jsonpath": "$.version"
         }


### PR DESCRIPTION
Make the plugin/ directory a valid Agent Plugins (v1) plugin:
- add plugin/plugin.json (spec manifest)
- add plugin/mcp.json declaring the db-context-engineering and toolbox MCP servers in spec format
- track plugin/plugin.json version via release-please
- document installation via compatible Agent Plugins clients

Skills already live under plugin/skills/ and conform to the Agent Skills spec, so no skill changes are needed.