### PR TITLE
feat(hillclimb): use evalbench pipeline_debug_info in gap analysis

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -71,12 +71,12 @@ export EVAL_GCP_PROJECT_REGION="global"
 
 # 5. Navigate to evals/ and execute the evaluation
 cd evals/
-uvx --default-index https://pypi.org/simple/ --from "google-evalbench==1.12.0" google-evalbench --experiment_config=core-cujs/run_gemini_cli.yaml
+uvx --default-index https://pypi.org/simple/ --from "google-evalbench==1.15.0" google-evalbench --experiment_config=core-cujs/run_gemini_cli.yaml
 ```
 
 To run Spanner Graph CUJs:
 ```bash
-uvx --default-index https://pypi.org/simple/ --from "google-evalbench==1.12.0" google-evalbench --experiment_config=spanner-graph-cujs/run_gemini_cli.yaml
+uvx --default-index https://pypi.org/simple/ --from "google-evalbench==1.15.0" google-evalbench --experiment_config=spanner-graph-cujs/run_gemini_cli.yaml
 ```
 
 ---
@@ -123,7 +123,7 @@ export EVAL_GCP_PROJECT_REGION="global"
 
 # Execute evalbench from evals/ directory
 cd evals
-uvx --default-index https://pypi.org/simple/ --from "google-evalbench==1.12.0" google-evalbench --experiment_config=spanner-graph-cujs/run_gemini_cli.yaml
+uvx --default-index https://pypi.org/simple/ --from "google-evalbench==1.15.0" google-evalbench --experiment_config=spanner-graph-cujs/run_gemini_cli.yaml
 ```
 
 ---

--- a/plugin/skills/context-engineering-evaluate/SKILL.md
+++ b/plugin/skills/context-engineering-evaluate/SKILL.md
@@ -72,7 +72,7 @@ Follow these steps exactly in order:
 
 4. **Evalbench Run Integration:**
    - Trigger the `run_shell_command` natively to execute the evaluation from the ROOT of the workspace using the following exact command template:
-     `uvx google-evalbench@1.12.0 --experiment_config=autoctx/experiments/<experiment_name>/eval_configs/run_config.yaml`
+     `uvx google-evalbench@1.15.0 --experiment_config=autoctx/experiments/<experiment_name>/eval_configs/run_config.yaml`
    - Check the command outputs to ensure the evaluation reports materialize in the respective `autoctx/experiments/<experiment_name>/eval_reports/` directory.
 
 ## Output

--- a/plugin/skills/context-engineering-hillclimb/SKILL.md
+++ b/plugin/skills/context-engineering-hillclimb/SKILL.md
@@ -46,6 +46,7 @@ Follow these steps exactly in order:
     -   Iterate through the failure cases by calling the tool with increasing `offset` (0, 10, 20, ...) until all failed queries are analyzed.
     -   **First Batch (offset=0)**: Initialize the report file with the `# Gap Analysis Report - vN` header and `## Summary` section, followed by the analysis of the first batch under `## Failed Queries Detail`.
     -   **Subsequent Batches**: Call the tool with the next offset, analyze the new failures, and **append** them to the `## Failed Queries Detail` section.
+    -   **Use `pipeline_debug_info`**: If a failure case's **Additional Output** contains it, use this generation trace (showing which context the API retrieved and used) to ground the **Root Cause** and **Proposed Mutation** rather than guessing. For example, if the trace shows no template matched a question that should have been covered, treat the missing blueprint match as the root cause.
 
     Use the following structure for the report:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
 
 [tool.db-context-engineering]
 toolbox_version = "1.4.0"
-evalbench_version = "1.12.0"
+evalbench_version = "1.15.0"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
Teaches the hill-climbing gap analysis to use pipeline_debug_info (the Query Data API's generation trace, surfaced in eval report Additional Output) to ground root-cause and proposed mutations. Bumps the evalbench pin to 1.16.0, the release that will include the pipeline_debug_info support (GoogleCloudPlatform/evalbench#570).

This PR won't be merged until we have a new EvalBench release.